### PR TITLE
Fix typo for llama32_vision_stateful_deploy_infer.ipynb

### DIFF
--- a/Llama3/llama3-11b-vision/stateful/llama32_vision_stateful_deploy_infer.ipynb
+++ b/Llama3/llama3-11b-vision/stateful/llama32_vision_stateful_deploy_infer.ipynb
@@ -232,7 +232,7 @@
    },
    "outputs": [],
    "source": [
-    "!cd code && torch-model-archiver --model-name {model_name} --version 1.0 --handler handler/custom_handler.py --config-file handler/model-config.yaml --archive-format no-archive --extra-files handler/ -f"
+    "!cd code && torch-model-archiver --model-name {model_name} --version 1.0 --handler handler/custom_handler.py --model-file handler/model-config.yaml --archive-format no-archive --extra-files handler/ -f"
    ]
   },
   {


### PR DESCRIPTION
usage: torch-model-archiver [-h] --model-name MODEL_NAME
                            [--serialized-file SERIALIZED_FILE]
                            [--model-file MODEL_FILE] --handler HANDLER
                            [--extra-files EXTRA_FILES]
                            [--runtime {python,python3}]
                            [--export-path EXPORT_PATH]
                            [--archive-format {tgz,no-archive,default}] [-f]
                            -v VERSION [-r REQUIREMENTS_FILE]
torch-model-archiver: error: unrecognized arguments: --config-file handler/model-config.yaml

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
