### PR TITLE
add basic scale to zero notebook

### DIFF
--- a/scale-to-zero-endpoint/basic-scale-to-zero-autoscaling.ipynb
+++ b/scale-to-zero-endpoint/basic-scale-to-zero-autoscaling.ipynb
@@ -1,0 +1,442 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Overview\n",
+    "\n",
+    "This modifies the [notebook](https://github.com/aws-samples/sagemaker-genai-hosting-examples/blob/main/scale-to-zero-endpoint/llama3-8b-scale-to-zero-autoscaling.ipynb) for scale-to-zero, but to *focus on deploying a basic model through the SageMaker endpoint workflow*.\n",
+    "\n",
+    "This is designe to interface scale-to-zero with traditional SageMaker endpoints that do not have inference components by default. \n",
+    "\n",
+    "**Core Issue**\n",
+    "\n",
+    "The “scale-to-zero” autoscaling `ManagedInstanceScaling` introduced in the AWS blog does not work on endpoint *models.* Rather, it integrates only with *inference components* which are a new and separate abstraction from the rest of the SageMaker SDK. This leads to:\n",
+    "\n",
+    "- No integration with traditional SageMaker inference endpoints\n",
+    "- No automatic integration with CloudWatch\n",
+    "- No automatic integration with auto scaling\n",
+    "- Broken integration with the AWS SageMaker Console.\n",
+    "\n",
+    "**Solution Overview**\n",
+    "\n",
+    "- Create an endpoint config and endpoint *without* a model\n",
+    "- Create a model without deploying to endpoint\n",
+    "- Create instance component from the model\n",
+    "- Attach the *instance component* to the endpoint\n",
+    "- Manually configure CloudWatch and autoscaling"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Session Overhead**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.pytorch import PyTorchModel\n",
+    "from sagemaker import get_execution_role\n",
+    "from sagemaker.serverless import ServerlessInferenceConfig\n",
+    "import sagemaker\n",
+    "import boto3\n",
+    "\n",
+    "# NOTE: Still using this us-west-2 region for thie GPU \n",
+    "# This needs to be specified if not operating from this region \n",
+    "boto_session = boto3.Session(region_name='us-west-2')\n",
+    "sagemaker_session = sagemaker.Session(boto_session=boto_session)\n",
+    "sagemaker_client = boto3.client(\"sagemaker\", region_name=\"us-west-2\")\n",
+    "role = sagemaker.get_execution_role()\n",
+    "assert sagemaker_session._region_name == 'us-west-2'\n",
+    "model_bucket = sagemaker_session.default_bucket()  # bucket to house model artifacts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Create Endpoint Config**\n",
+    "\n",
+    "The endpoint *config* is separate from an endpoint object. Normally, the `model.deploy()` function creates this config behind the scenes. You can also create an endpoint config from the AWS console. This function of code creates the config programmatically with the SageMaker SDK. \n",
+    "\n",
+    "The important part of this config is the addition of the “scale-to-zero” functionality. This snippet also closely follows the reference blog. The `ManagedInstanceScaling` snippet is important to enable the new scale-to-zero feature."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#### Create Endpoint Config\n",
+    "prefix = sagemaker.utils.unique_name_from_base(\"DEMO\")\n",
+    "print(f\"prefix: {prefix}\")\n",
+    "variant_name = \"AllTraffic\"\n",
+    "# Large A10G machine to process pipeline\n",
+    "# 16 vCPUs\n",
+    "instance_type = \"ml.g5.4xlarge\"\n",
+    "model_data_download_timeout_in_seconds = 3600\n",
+    "container_startup_health_check_timeout_in_seconds = 3600\n",
+    "\n",
+    "min_instance_count = 0 # Minimum instance must be set to 0\n",
+    "max_instance_count = 1\n",
+    "\n",
+    "# Config creation function\n",
+    "sagemaker_client.create_endpoint_config(\n",
+    "    EndpointConfigName='scale-to-zero-endpoint-config',\n",
+    "    ExecutionRoleArn=role,\n",
+    "    ProductionVariants=[\n",
+    "        {\n",
+    "            \"VariantName\": variant_name, # NOTE: ModelName in config will NOT work\n",
+    "            \"InstanceType\": instance_type,\n",
+    "            \"InitialInstanceCount\": 1,\n",
+    "            \"ModelDataDownloadTimeoutInSeconds\": model_data_download_timeout_in_seconds,\n",
+    "            \"ContainerStartupHealthCheckTimeoutInSeconds\": container_startup_health_check_timeout_in_seconds,\n",
+    "            \"ManagedInstanceScaling\": {\n",
+    "                \"Status\": \"ENABLED\",\n",
+    "                \"MinInstanceCount\": min_instance_count,\n",
+    "                \"MaxInstanceCount\": max_instance_count,\n",
+    "            },\n",
+    "            \"RoutingConfig\": {\"RoutingStrategy\": \"LEAST_OUTSTANDING_REQUESTS\"},\n",
+    "        }\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is also worth mentioning that in the SageMaker Docs, it says that you can just add `ModelName` directly to the [EndpointConfig](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateEndpointConfig.html)\n",
+    "\n",
+    "This is true if you are deploying a normal endpoint to SageMaker. However, when deploying with fancier new keys like `ManagedInstanceScaling`, you will receive the IAM error:\n",
+    "\n",
+    "`ExecutionRoleArn is not supported with the given EndpointConfig setup.`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Create Empty Endpoint**\n",
+    "\n",
+    "Now that we have the endpoint config, we can deploy an endpoint from it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "endpoint_name = f\"{prefix}-example-endpoint\"\n",
+    "print(f\"Endpoint name: {endpoint_name}\")\n",
+    "\n",
+    "sagemaker_client.create_endpoint(\n",
+    "    EndpointName=endpoint_name,\n",
+    "    EndpointConfigName='example-endpoint-config',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note, this endpoint does not have a Model. After this deploys, it will even scale up to 1 instance - but you cannot perform inference on it. \n",
+    "\n",
+    "One would think you can update the endpoint by adding a model to it with the SageMaker `UpdateEndpoint` [API:](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_UpdateEndpoint.html)\n",
+    "\n",
+    "This yields the error: \n",
+    "`\"ClientError: An error occurred (ValidationException) when calling the UpdateEndpoint operation: Cannot update in-progress endpoint\"`\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Create SageMaker Model**\n",
+    "\n",
+    "These steps are similar to our normal workflow. There is one exception: we do not call `model.deploy()` . \n",
+    "\n",
+    "The objective of this is to deploy a `Model` class, but not deploy it to a specific endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (NOTE: update model.tar.gz. file if changes to inference code)\n",
+    "model_data = sagemaker_session.upload_data(\n",
+    "    path=\"model.tar.gz\",\n",
+    "    bucket=sagemaker_session.default_bucket(),\n",
+    "    key_prefix=\"models/model\"\n",
+    ")\n",
+    "    \n",
+    "model = PyTorchModel(\n",
+    "    model_data=model_data,\n",
+    "    role=get_execution_role(),\n",
+    "    entry_point=\"inference.py\",\n",
+    "    source_dir=\"code\",\n",
+    "    sagemaker_session=sagemaker_session,\n",
+    "    framework_version=\"2.3\",\n",
+    "    env={\"PYTHONUNBUFFERED\": \"1\"},\n",
+    "    py_version=\"py311\",\n",
+    "    # transformers_version=\"4.37\",\n",
+    "    code_location=f\"s3://{sagemaker_session.default_bucket()}/code\",\n",
+    ")\n",
+    "\n",
+    "## DO NOT DEPLOY\n",
+    "# model.deploy(\n",
+    "#     instance_type='ml.g5.4xlarge',\n",
+    "#     endpoint_name=\"example-endpoint-name\",\n",
+    "#     initial_instance_count=1\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Create Inference Components**\n",
+    "\n",
+    "This is what took the longest for me to figure out. \n",
+    "\n",
+    "SageMaker inference components are a new version of endpoint provisioning designed for LLM [deployments:](https://aws.amazon.com/blogs/aws/amazon-sagemaker-adds-new-inference-capabilities-to-help-reduce-foundation-model-deployment-costs-and-latency/)\n",
+    "\n",
+    "They don’t follow the traditional `Model + EndpointConfig -> Inference Endpoint` setup that SageMaker uses otherwise. They are instead additional configurations that you can invoke for inference on an individual endpoint. It seems to be good for hosting multiple models per endpoint etc.\n",
+    "\n",
+    "But importantly for this, the new `ManagedInstanceScaling` part of the Endpoint Config expects to scale inference components, NOT endpoint Models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "##### Create Inference Components\n",
+    "sagemaker_client.create_inference_component(\n",
+    "    InferenceComponentName=\"scale-to-zero-inference-component\",\n",
+    "    EndpointName=\"scale-to-zero-endpoint\",\n",
+    "    VariantName=\"AllTraffic\",\n",
+    "    Specification={\n",
+    "        \"ModelName\": \"example-model-name\",\n",
+    "        \"ComputeResourceRequirements\": {\n",
+    "\t\t    \"NumberOfAcceleratorDevicesRequired\": 1, \n",
+    "\t\t\t\"NumberOfCpuCoresRequired\": 2, \n",
+    "\t\t\t\"MinMemoryRequiredInMb\": 1024\n",
+    "\t    }\n",
+    "    },\n",
+    "    RuntimeConfig={\"CopyCount\": 1},\n",
+    ")\n",
+    "# Describe inference component\n",
+    "response = sagemaker_client.describe_inference_component(\n",
+    "    InferenceComponentName='console-endpoint-inference-component'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Create AutoScaling Policies and Log Groups for Inference Component**\n",
+    "\n",
+    "- Inference components do not have a log group created automatically, so we have to create them.\n",
+    "- You cannot configure autoscaling for inference components from the AWS console, so you have to do it programmatically, too. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aas_client = sagemaker_session.boto_session.client(\"application-autoscaling\", region_name='us-west-2')\n",
+    "cloudwatch_client = sagemaker_session.boto_session.client(\"cloudwatch\", region_name='us-west-2')\n",
+    "inference_component_name = 'scale-to-zero-inference-component'\n",
+    "\n",
+    "# Autoscaling parameters\n",
+    "resource_id = f\"inference-component/{inference_component_name}\"\n",
+    "service_namespace = \"sagemaker\"\n",
+    "scalable_dimension = \"sagemaker:inference-component:DesiredCopyCount\"\n",
+    "min_copy_count = 0\n",
+    "max_copy_count = 2\n",
+    "\n",
+    "aas_client.register_scalable_target(\n",
+    "    ServiceNamespace=service_namespace,\n",
+    "    ResourceId=resource_id,\n",
+    "    ScalableDimension=scalable_dimension,\n",
+    "    MinCapacity=min_copy_count,\n",
+    "    MaxCapacity=max_copy_count,\n",
+    ")\n",
+    "\n",
+    "aas_client.describe_scalable_targets(\n",
+    "    ServiceNamespace=service_namespace,\n",
+    "    ResourceIds=[resource_id],\n",
+    "    ScalableDimension=scalable_dimension,\n",
+    ")\n",
+    "\n",
+    "# The policy name for the target traking policy\n",
+    "target_tracking_policy_name = f\"scale-to-zero-endpoint-{inference_component_name}\"\n",
+    "\n",
+    "aas_client.put_scaling_policy(\n",
+    "    PolicyName=target_tracking_policy_name,\n",
+    "    PolicyType=\"TargetTrackingScaling\",\n",
+    "    ServiceNamespace=service_namespace,\n",
+    "    ResourceId=resource_id,\n",
+    "    ScalableDimension=scalable_dimension,\n",
+    "    TargetTrackingScalingPolicyConfiguration={\n",
+    "        \"PredefinedMetricSpecification\": {\n",
+    "            \"PredefinedMetricType\": \"SageMakerInferenceComponentConcurrentRequestsPerCopyHighResolution\",\n",
+    "        },\n",
+    "        # Low TPS + load TPS\n",
+    "        \"TargetValue\": 5,  # you need to adjust this value based on your use case\n",
+    "        \"ScaleInCooldown\": 300,  # default\n",
+    "        \"ScaleOutCooldown\": 300,  # default\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# The policy name for the step scaling policy\n",
+    "step_scaling_policy_name = f\"scale-to-zero-endpoint-{inference_component_name}\"\n",
+    "\n",
+    "aas_client.put_scaling_policy(\n",
+    "    PolicyName=step_scaling_policy_name,\n",
+    "    PolicyType=\"StepScaling\",\n",
+    "    ServiceNamespace=service_namespace,\n",
+    "    ResourceId=resource_id,\n",
+    "    ScalableDimension=scalable_dimension,\n",
+    "    StepScalingPolicyConfiguration={\n",
+    "        \"AdjustmentType\": \"ChangeInCapacity\",\n",
+    "        \"MetricAggregationType\": \"Maximum\",\n",
+    "        \"Cooldown\": 60,\n",
+    "        \"StepAdjustments\":\n",
+    "          [\n",
+    "             {\n",
+    "               \"MetricIntervalLowerBound\": 0,\n",
+    "               \"ScalingAdjustment\": 1\n",
+    "             }\n",
+    "          ]\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "resp = aas_client.describe_scaling_policies(\n",
+    "    PolicyNames=[step_scaling_policy_name],\n",
+    "    ServiceNamespace=service_namespace,\n",
+    "    ResourceId=resource_id,\n",
+    "    ScalableDimension=scalable_dimension,\n",
+    ")\n",
+    "step_scaling_policy_arn = resp['ScalingPolicies'][0]['PolicyARN']\n",
+    "print(f\"step_scaling_policy_arn: {step_scaling_policy_arn}\")\n",
+    "\n",
+    "# The alarm name for the step scaling alarm\n",
+    "step_scaling_alarm_name = f\"console-endpoint-{inference_component_name}\"\n",
+    "\n",
+    "cloudwatch_client.put_metric_alarm(\n",
+    "    AlarmName=step_scaling_alarm_name,\n",
+    "    AlarmActions=[step_scaling_policy_arn],  # Replace with your actual ARN\n",
+    "    MetricName='NoCapacityInvocationFailures',\n",
+    "    Namespace='AWS/SageMaker',\n",
+    "    Statistic='Maximum',\n",
+    "    Dimensions=[\n",
+    "        {\n",
+    "            'Name': 'InferenceComponentName',\n",
+    "            'Value': inference_component_name  # Replace with actual InferenceComponentName\n",
+    "        }\n",
+    "    ],\n",
+    "    Period=30, # Set a lower period \n",
+    "    EvaluationPeriods=1,\n",
+    "    DatapointsToAlarm=1,\n",
+    "    Threshold=1,\n",
+    "    ComparisonOperator='GreaterThanOrEqualToThreshold',\n",
+    "    TreatMissingData='missing'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Endpoint Monitoring**\n",
+    "\n",
+    "You can use these python commands to monitor aspects of the endpoint: \n",
+    "\n",
+    "Describing the inference component:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sagemaker_client.describe_inference_component(InferenceComponentName=inference_component_name)\n",
+    "sagemaker_client.describe_endpoint(EndpointName='console-endpoint')\n",
+    "sagemaker_client.describe_endpoint(EndpointName='console-endpoint')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Important Notes on the console:** \n",
+    "\n",
+    "There will be an error specifying your endpoint does not have a `ModelName` (which is true, it has an inference component instead). There does not seem to be support for inference components in the dashboard.\n",
+    "\n",
+    "The “Desired Instance Count” should reflect the actual autoscaling and billing accurately.\n",
+    "\n",
+    "\n",
+    "One cannot configure autoscaling in the Console. This is because ManagedInstanceScaling is NOT actually “Auto Scaling” in SageMaker. It is a different API, geared towards instance components, not endpoint models. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Endpoint Invocation**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import boto3\n",
+    "runtime = boto3.client('sagemaker-runtime', region='us-west-2')\n",
+    "payload = {\n",
+    "    \"key\": \"value\"\n",
+    "}\n",
+    "response = runtime.invoke_endpoint(\n",
+    "    EndpointName='example-endpoint',\n",
+    "    ContentType='application/json',\n",
+    "    Body=json.dumps(payload),\n",
+    "  InferenceComponentName='example-inference-component' # must specify inference component name\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**Core Issue**

The “scale-to-zero” autoscaling `ManagedInstanceScaling` introduced in the AWS blog does not work on endpoint *models.* Rather, it integrates only with *inference components* which are a new and separate abstraction from the rest of the SageMaker SDK. This leads to:

- No integration with traditional SageMaker inference endpoints
- No automatic integration with CloudWatch
- No automatic integration with auto scaling
- Broken integration with the AWS SageMaker Console.

**Solution Overview**

- Create an endpoint config and endpoint *without* a model
- Create a model without deploying to endpoint
- Create instance component from the model
- Attach the *instance component* to the endpoint
- Manually configure CloudWatch and autoscaling

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
