### PR TITLE
Added benchmarking script for LMIv14 and LMIv15

### DIFF
--- a/Llama3.1/Benchmarking-LMI-containers-Llama3p1-Instruct.ipynb
+++ b/Llama3.1/Benchmarking-LMI-containers-Llama3p1-Instruct.ipynb
@@ -1,0 +1,421 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0262c242-8e24-40d1-97e0-97bf96105e3c",
+   "metadata": {},
+   "source": [
+    "### Load session and Hugging Face token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79636916-6eef-4bc9-ae6e-78b25bdf5f42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install huggingface_hub --quiet\n",
+    "!git config --global credential.helper store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7bcfe17a-c456-4fe1-8ca0-d98e2c11dca8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import sagemaker\n",
+    "from botocore.config import Config\n",
+    "\n",
+    "boto_session = boto3.session.Session()\n",
+    "region = boto_session.region_name\n",
+    "\n",
+    "no_retry_config = Config(retries={'max_attempts': 1})\n",
+    "\n",
+    "sm_session = sagemaker.Session(\n",
+    "    boto_session=boto3.session.Session(),\n",
+    "    sagemaker_client=boto3.client(\"sagemaker\", config=no_retry_config),\n",
+    "    sagemaker_runtime_client=boto3.client(\"sagemaker-runtime\", config=no_retry_config),\n",
+    ")\n",
+    "\n",
+    "role = sagemaker.get_execution_role()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65f3b935-040e-4660-8ec5-06c6ab56c2f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from huggingface_hub import notebook_login\n",
+    "\n",
+    "notebook_login()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd3c46c5-db48-443c-b9bb-e59ef6247d25",
+   "metadata": {},
+   "source": [
+    "### Serving properties for LMI v15 and LMI v14\n",
+    "\n",
+    "Using `async_mode` for serving in the LMI v15 container, and using `rolling_batch` in the LMI v14 container."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05391667-4bc0-4f5d-b801-3649fe8b4261",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from huggingface_hub import HfFolder\n",
+    "from sagemaker.djl_inference.model import DJLModel\n",
+    "import os\n",
+    "\n",
+    "# Images for LMIv14 and LMIv15\n",
+    "image_v14 = f\"763104351884.dkr.ecr.{region}.amazonaws.com/djl-inference:0.32.0-lmi14.0.0-cu124\"\n",
+    "image_v15 = f\"763104351884.dkr.ecr.{region}.amazonaws.com/djl-inference:0.33.0-lmi15.0.0-cu128-v1.0\"\n",
+    "\n",
+    "# Serving properties\n",
+    "HF_MODEL_ID = \"meta-llama/Llama-3.1-8B-Instruct\"\n",
+    "MAX_MODEL_LEN = \"1024\"\n",
+    "BATCH_SIZE = \"64\"\n",
+    "\n",
+    "lmi_v15_config = {\n",
+    "    \"HF_MODEL_ID\": HF_MODEL_ID,\n",
+    "    \"HF_TOKEN\": HfFolder.get_token(),\n",
+    "    \"OPTION_TRUST_REMOTE_CODE\": \"true\",\n",
+    "    \"SERVING_ENGINE\": \"Python\",\n",
+    "    \"OPTION_MAX_ROLLING_BATCH_SIZE\":BATCH_SIZE,\n",
+    "    \"OPTION_MODEL_LOADING_TIMEOUT\":\"1800\",\n",
+    "    \"OPTION_MAX_MODEL_LEN\": MAX_MODEL_LEN,\n",
+    "    \"SERVING_FAIL_FAST\":\"true\",\n",
+    "    \"OPTION_ROLLING_BATCH\":\"disable\",\n",
+    "    \"OPTION_ASYNC_MODE\":\"true\",\n",
+    "    \"OPTION_ENTRYPOINT\":\"djl_python.lmi_vllm.vllm_async_service\",\n",
+    "}\n",
+    "model_v15 = DJLModel(\n",
+    "    env=lmi_v15_config,\n",
+    "    role=role,\n",
+    "    image_uri=image_v15,\n",
+    "    )\n",
+    "\n",
+    "lmi_v14_config = {\n",
+    "    \"HF_MODEL_ID\": HF_MODEL_ID,\n",
+    "    \"HF_TOKEN\": HfFolder.get_token(),\n",
+    "    \"OPTION_TRUST_REMOTE_CODE\": \"true\",\n",
+    "    \"SERVING_ENGINE\": \"Python\",\n",
+    "    \"OPTION_TENSOR_PARALLEL_DEGREE\": \"1\",\n",
+    "    \"OPTION_MAX_ROLLING_BATCH_SIZE\": BATCH_SIZE,\n",
+    "    \"OPTION_ROLLING_BATCH\": \"vllm\",\n",
+    "    \"OPTION_MAX_ROLLING_BATCH_PREFILL_TOKENS\": MAX_MODEL_LEN,\n",
+    "    \"OPTION_MAX_MODEL_LEN\": MAX_MODEL_LEN,\n",
+    "    \"OPTION_ENABLE_PREFIX_CACHING\": \"False\",\n",
+    "}\n",
+    "\n",
+    "model_v14 = DJLModel(\n",
+    "    env=lmi_v14_config,\n",
+    "    role=role,\n",
+    "    image_uri=image_v14,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95a32a61-5a3a-4864-b22c-e7330271c79b",
+   "metadata": {},
+   "source": [
+    "### Deploy model with LMI v15 and LMI v14"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8fa50df-e569-47d3-98cc-253ee72730e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "INSTANCE_TYPE = \"ml.g6e.2xlarge\"\n",
+    "\n",
+    "predictor_v15 = model_v15.deploy(\n",
+    "    initial_instance_count=1,\n",
+    "    instance_type=INSTANCE_TYPE,\n",
+    "    endpoint_name=sagemaker.utils.name_from_base(\"lmi-v15\"),\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5e2d5e2-94b4-4e77-b967-4ea786b8e381",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictor_v14 = model_v14.deploy(\n",
+    "    initial_instance_count=1,\n",
+    "    instance_type=INSTANCE_TYPE,\n",
+    "    endpoint_name=sagemaker.utils.name_from_base(\"lmi-v14\"),\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aca75a3b-b231-4cf6-99ab-8fed8b34a9b2",
+   "metadata": {},
+   "source": [
+    "### Invoking the model using the OpenAI schema\n",
+    "\n",
+    "Changing the shape of the request depending on the version of the LMI container being used. The following cells download Shakespeare's sonnet to use it in token benchmarking tests, in an approach similar to `LLMPerf` but without having to install the library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71575931-1f9a-4312-91cd-9bde168d3e15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -O https://raw.githubusercontent.com/ray-project/llmperf/refs/heads/main/src/llmperf/sonnet.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91a70a95-f1cf-48f8-a594-3525473f2970",
+   "metadata": {},
+   "source": [
+    "### Calculate metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68dedfa5-a8df-4aff-98c1-3ed6dc7f814b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np \n",
+    "import datetime\n",
+    "import time\n",
+    "import boto3   \n",
+    "import matplotlib.pyplot as plt\n",
+    "from joblib import Parallel, delayed\n",
+    "import numpy as np\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "from benchmarking_utils import inference_latency"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fab03de-a02d-404d-82be-bd836d7d9359",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Callable, Tuple, Any\n",
+    "from joblib import Parallel, delayed\n",
+    "from tqdm import tqdm\n",
+    "import numpy as np\n",
+    "from transformers import LlamaTokenizerFast\n",
+    "\n",
+    "def run_benchmark(\n",
+    "    predictor: Callable,\n",
+    "    number_of_clients: int,\n",
+    "    number_of_runs: int,\n",
+    "    openai_chat_completions: bool\n",
+    ") -> Tuple[float, float]:\n",
+    "    \"\"\"\n",
+    "    Run a benchmark to measure token throughput and median latency of a prediction function.\n",
+    "\n",
+    "    Args:\n",
+    "        predictor (Callable): The function or model used to generate predictions.\n",
+    "        number_of_clients (int): The number of parallel clients to simulate.\n",
+    "        number_of_runs (int): The total number of benchmark runs to execute.\n",
+    "        openai_chat_completions (bool): Flag indicating if OpenAI-style chat completions \n",
+    "                                        are being used (True) or if we are following the\n",
+    "                                        Hugging Face schema (False).\n",
+    "\n",
+    "    Returns:\n",
+    "        Tuple[float, float]: A tuple containing:\n",
+    "            - token_throughput (float): Total tokens generated divided by elapsed time (tokens/sec).\n",
+    "            - p50_latency_ms (float): The 50th percentile (median) latency in milliseconds.\n",
+    "    \"\"\"\n",
+    "    progress_bar = tqdm(range(number_of_runs), position=0, leave=True)\n",
+    "\n",
+    "    results = Parallel(n_jobs=number_of_clients, prefer=\"threads\")(\n",
+    "        delayed(inference_latency)(predictor, openai_chat_completions)\n",
+    "        for _ in progress_bar\n",
+    "    )\n",
+    "\n",
+    "    latencies = [res['latency'] for res in results]\n",
+    "    p50_latency_ms = float(np.quantile(latencies, 0.50))\n",
+    "\n",
+    "    if openai_chat_completions:\n",
+    "        tokens = [res['result']['usage']['completion_tokens'] for res in results]\n",
+    "    else:\n",
+    "        tokenizer = LlamaTokenizerFast.from_pretrained(\"hf-internal-testing/llama-tokenizer\")\n",
+    "        tokens = [\n",
+    "            len(tokenizer.encode(res['result']['generated_text']))\n",
+    "            for res in results\n",
+    "        ]\n",
+    "\n",
+    "    elapsed_time = progress_bar.format_dict['elapsed'] or 1e-6  # Avoid division by zero\n",
+    "    token_throughput = sum(tokens) / elapsed_time\n",
+    "\n",
+    "    return token_throughput, p50_latency_ms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acf7e0f9-106b-4cb3-9595-da96001d4b5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from typing import Callable, List\n",
+    "from pandas import DataFrame\n",
+    "\n",
+    "def store_metrics(\n",
+    "    predictor: Callable,\n",
+    "    num_requests: int = 512,\n",
+    "    num_clients_list: List[int] = [16, 32, 64],\n",
+    "    openai_chat_completions: bool = True\n",
+    ") -> DataFrame:\n",
+    "    \"\"\"\n",
+    "    Run benchmark tests with varying levels of concurrency and collect performance metrics.\n",
+    "\n",
+    "    Args:\n",
+    "        predictor (Callable): The function or model used to generate predictions.\n",
+    "        num_requests (int, optional): Total number of requests to simulate for each concurrency level. Default is 512.\n",
+    "        num_clients_list (List[int], optional): A list of client counts (concurrency levels) to test. Default is [16, 32, 64].\n",
+    "        openai_chat_completions (bool, optional): Flag indicating whether the model returns OpenAI-style completions \n",
+    "                                                  with token usage stats (True) or requires manual tokenization (False).\n",
+    "\n",
+    "    Returns:\n",
+    "        pd.DataFrame: A DataFrame containing the p50 latency (ms) and token throughput (tokens/sec) for each concurrency level.\n",
+    "    \"\"\"\n",
+    "    p50_latency_list = []\n",
+    "    token_throughput_list = []\n",
+    "\n",
+    "    for num_clients in num_clients_list:\n",
+    "        avg_token_throughput, p50_latency = run_benchmark(\n",
+    "            predictor,\n",
+    "            number_of_clients=num_clients,\n",
+    "            number_of_runs=num_requests,\n",
+    "            openai_chat_completions=openai_chat_completions\n",
+    "        )\n",
+    "        p50_latency_list.append(p50_latency)\n",
+    "        token_throughput_list.append(avg_token_throughput)\n",
+    "\n",
+    "    results_df = pd.DataFrame({\n",
+    "        \"p50_latency_ms\": p50_latency_list,\n",
+    "        \"token_per_s\": token_throughput_list,\n",
+    "    }, index=num_clients_list)\n",
+    "\n",
+    "    results_df.index.name = \"num_clients\"\n",
+    "\n",
+    "    return results_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c929766-478c-46ff-9cd5-75b8c930fc10",
+   "metadata": {},
+   "source": [
+    "### Run benchmarking tests and plot results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5bcfb0e4-b3af-4950-9831-ebc5b9e86aa0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define parameters for benchmarking test\n",
+    "num_clients = [16,32,64]\n",
+    "num_requests = 512\n",
+    "\n",
+    "# Run tests for LMIv15 and LMIv14\n",
+    "df_v15 = store_metrics(predictor_v15, num_requests, num_clients, True)\n",
+    "df_v15.index = num_clients\n",
+    "\n",
+    "df_v14 = store_metrics(predictor_v14, num_requests, num_clients, False)\n",
+    "df_v14.index = num_clients"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21e3b9db-c93d-4de7-9411-8ed67eccb5ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(10, 5))\n",
+    "\n",
+    "# Plot p50 Latency\n",
+    "axes[0].plot(df_v14.index, df_v14[\"p50_latency_ms\"], marker='o', linestyle='--', color='steelblue', label='LMIv14')\n",
+    "axes[0].plot(df_v15.index, df_v15[\"p50_latency_ms\"], marker='o', linestyle='--', color='firebrick', label='LMIv15')\n",
+    "axes[0].set_title(\"p50 Latency\")\n",
+    "axes[0].set_xlabel(\"Concurrent Clients\")\n",
+    "axes[0].set_ylabel(\"Latency (ms)\")\n",
+    "axes[0].grid(True)\n",
+    "axes[0].legend()\n",
+    "\n",
+    "# Plot Token Throughput\n",
+    "axes[1].plot(df_v14.index, df_v14[\"token_per_s\"], marker='o', linestyle='--', color='steelblue', label='LMIv14')\n",
+    "axes[1].plot(df_v15.index, df_v15[\"token_per_s\"], marker='o', linestyle='--', color='firebrick', label='LMIv15')\n",
+    "axes[1].set_title(\"Throughput\")\n",
+    "axes[1].set_xlabel(\"Concurrent Clients\")\n",
+    "axes[1].set_ylabel(\"Tokens per second\")\n",
+    "axes[1].grid(True)\n",
+    "axes[1].legend()\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.savefig(\"benchmark_g6e_2xlarge_compared.png\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f94dbf7b-fad5-4917-9c9c-8da5d4c6eb62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictor_v14.delete_endpoint()\n",
+    "predictor_v15.delete_endpoint()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Llama3.1/benchmarking_utils.py
+++ b/Llama3.1/benchmarking_utils.py
@@ -1,0 +1,128 @@
+"""
+These functions were adapted from utils.py in LLMPerf
+"""
+
+import random
+import math
+from transformers import LlamaTokenizerFast
+from typing import Any, Dict, List, Optional, Tuple
+
+def sample_random_positive_int(mean: int, stddev: int) -> int:
+    """Sample random numbers from a gaussian distribution until a positive number is sampled.
+
+    Args:
+        mean: The mean of the gaussian distribution to sample from.
+        stddev: The standard deviation of the gaussian distribution to sample from.
+
+    Returns:
+        A random positive integer sampled from the gaussian distribution.
+    """
+    ret = -1
+    while ret <= 0:
+        ret = int(random.gauss(mean, stddev))
+    return ret
+
+def randomly_sample_sonnet_lines_prompt(
+    openai_chat_completions: bool = True,
+    prompt_tokens_mean: int = 800,
+    prompt_tokens_stddev: int = 10,
+    expect_output_tokens: int = 1000,
+    tokenizer = LlamaTokenizerFast.from_pretrained(
+        "hf-internal-testing/llama-tokenizer")
+) -> Tuple[str, int]:
+    """Generate a prompt that randomly samples lines from a the shakespeare sonnet at sonnet.txt.
+
+    Args:
+        prompt_length_mean: The mean length of the prompt to generate.
+        prompt_len_stddev: The standard deviation of the length of the prompt to generate.
+        expect_output_tokens: The number of tokens to expect in the output. This is used to
+        determine the length of the prompt. The prompt will be generated such that the output
+        will be approximately this many tokens.
+
+    Note:
+        tokens will be counted from the sonnet using the Llama tokenizer. Using one tokenizer
+        ensures a fairer comparison across different LLMs. For example, if gpt 3.5 tokenizes
+        a prompt in less tokens than Llama2, then this will be reflected in the results since
+        they will be fed identical prompts.
+
+    Returns:
+        A tuple of the prompt and the length of the prompt.
+    """
+
+    get_token_length = lambda text: len(tokenizer.encode(text))
+
+    prompt = (
+        "Randomly stream lines from the following text "
+        f"with {expect_output_tokens} output tokens. "
+        "Don't generate eos tokens:\n\n"
+    )
+    # get a prompt length that is at least as long as the base
+    num_prompt_tokens = sample_random_positive_int(
+        prompt_tokens_mean, prompt_tokens_stddev
+    )
+    while num_prompt_tokens < get_token_length(prompt):
+        num_prompt_tokens = sample_random_positive_int(
+            prompt_tokens_mean, prompt_tokens_stddev
+        )
+    remaining_prompt_tokens = num_prompt_tokens - get_token_length(prompt)
+    sonnet_path = "sonnet.txt"
+    with open(sonnet_path, "r") as f:
+        sonnet_lines = f.readlines()
+    random.shuffle(sonnet_lines)
+    sampling_lines = True
+    while sampling_lines:
+        for line in sonnet_lines:
+            line_to_add = line
+            if remaining_prompt_tokens - get_token_length(line_to_add) < 0:
+                # This will cut off a line in the middle of a word, but that's ok since an
+                # llm should be able to handle that.
+                line_to_add = line_to_add[: int(math.ceil(remaining_prompt_tokens))]
+                sampling_lines = False
+                prompt += line_to_add
+                break
+            prompt += line_to_add
+            remaining_prompt_tokens -= get_token_length(line_to_add)
+    # Prepare a request with the selected schema
+    if openai_chat_completions:
+        request = {
+              "messages": [
+                {"role": "user", "content": prompt}
+              ],
+              "max_tokens": expect_output_tokens,
+              "temperature": 0.75,
+              "stop": None
+            }
+    else:
+        request = {
+            "inputs": prompt,
+            "parameters": {
+                "max_new_tokens": expect_output_tokens,
+                "temperature": 0.75
+                }
+            }
+
+    return (request, num_prompt_tokens)
+
+import time
+
+def inference_latency(model,
+                      openai_chat_completions: bool = True,
+                      prompt_tokens_mean: int = 250,
+                      prompt_tokens_stddev: int = 10,
+                      expect_output_tokens: int = 500,
+                      tokenizer = LlamaTokenizerFast.from_pretrained("hf-internal-testing/llama-tokenizer")
+                     ):
+    error = False
+    (request, _) = randomly_sample_sonnet_lines_prompt(
+        openai_chat_completions,
+        prompt_tokens_mean,
+        prompt_tokens_stddev,
+        expect_output_tokens,
+        )
+    start = time.time()
+    try:
+        results = model.predict(request)
+    except:
+        error = True
+        results = []
+    return {'latency': (time.time() - start)*1000.0, 'error': error, 'result': results}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Included the notebook `Benchmarking-LMI-containers-Llama3p1-Instruct.ipynb` that shows how to run a benchmarking test for LMIv14 and LMIv15 containers. The sample was written for Llama 3.1, but it can be used with other models that support the OpenAI schema for messages (e.g., DeepSeek R1 Distill Llama, Mistral Instruct).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
