### PR TITLE
Remove TLS config for jumpstart and s3

### DIFF
--- a/SageMakerHyperpod/hyperpod-inference/deploy_S3_inference_operator.yaml
+++ b/SageMakerHyperpod/hyperpod-inference/deploy_S3_inference_operator.yaml
@@ -59,5 +59,3 @@ spec:
         value: "20"
       - name: SAGEMAKER_ENV
         value: "1"
-  tlsConfig:
-    tlsCertificateOutputS3Uri: "s3://bucket-name/certificates"

--- a/SageMakerHyperpod/hyperpod-inference/deploy_jumpstart_inference_operator.yaml
+++ b/SageMakerHyperpod/hyperpod-inference/deploy_jumpstart_inference_operator.yaml
@@ -18,8 +18,6 @@ spec:
     - name: SAMPLE_ENV_VAR
       value: "sample_value"
   maxDeployTimeInSeconds: 1800
-  tlsConfig:
-    tlsCertificateOutputS3Uri: "s3://bucket-name/certificates"
   autoScalingSpec:
     cloudWatchTrigger:
       name: "SageMaker-Invocations"


### PR DESCRIPTION
*Description of changes:*
For jumpstart and s3, Deployment not able to fetch the correct S3 uri that is already setup during operator installation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
