### PR TITLE
Remove TLS config for jumpstart, s3 and fsx

### DIFF
--- a/SageMakerHyperpod/hyperpod-inference/deploy_S3_inference_operator.yaml
+++ b/SageMakerHyperpod/hyperpod-inference/deploy_S3_inference_operator.yaml
@@ -59,5 +59,3 @@ spec:
         value: "20"
       - name: SAGEMAKER_ENV
         value: "1"
-  tlsConfig:
-    tlsCertificateOutputS3Uri: "s3://bucket-name/certificates"

--- a/SageMakerHyperpod/hyperpod-inference/deploy_fsx_lustre_inference_operator.yaml
+++ b/SageMakerHyperpod/hyperpod-inference/deploy_fsx_lustre_inference_operator.yaml
@@ -13,8 +13,6 @@ spec:
       fileSystemId: fs-1234abcd
     modelLocation: deepseek-1-5b
     modelSourceType: fsx
-  tlsConfig:
-    tlsCertificateOutputS3Uri: s3://<bucket-name>/certificates/
   worker:
     environmentVariables:
     - name: HF_MODEL_ID

--- a/SageMakerHyperpod/hyperpod-inference/deploy_jumpstart_inference_operator.yaml
+++ b/SageMakerHyperpod/hyperpod-inference/deploy_jumpstart_inference_operator.yaml
@@ -18,8 +18,6 @@ spec:
     - name: SAMPLE_ENV_VAR
       value: "sample_value"
   maxDeployTimeInSeconds: 1800
-  tlsConfig:
-    tlsCertificateOutputS3Uri: "s3://bucket-name/certificates"
   autoScalingSpec:
     cloudWatchTrigger:
       name: "SageMaker-Invocations"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For jumpstart, s3 and fsx, Deployment not able to fetch the correct S3 uri that is already setup during operator installation

*Testing:*
With removal the this field, deployment works as expected with the model deployment and invoking

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
