### PR TITLE
Fix GPT-OSS BYOC tool calling

### DIFF
--- a/OpenAI/gpt-oss/deploy/docker/Dockerfile
+++ b/OpenAI/gpt-oss/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM vllm/vllm-openai:v0.10.1
+FROM vllm/vllm-openai:v0.10.2
 
 COPY serve /usr/bin/serve
 RUN chmod 777 /usr/bin/serve

--- a/OpenAI/gpt-oss/deploy/docker/build.sh
+++ b/OpenAI/gpt-oss/deploy/docker/build.sh
@@ -1,7 +1,7 @@
 export REGION=YOUR_REGION
 export ACCOUNT_ID=YOUR_ACCOUNT_ID
 export REPOSITORY_NAME=vllm
-export TAG=v0.10.1
+export TAG=v0.10.2
 
 full_name="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${REPOSITORY_NAME}:${TAG}"
 

--- a/OpenAI/gpt-oss/deploy/docker/serve
+++ b/OpenAI/gpt-oss/deploy/docker/serve
@@ -6,7 +6,8 @@ ARG_PREFIX="--"
 
 # Initialize an array for storing the arguments
 # port 8080 required by sagemaker, https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html#your-algorithms-inference-code-container-response
-ARGS=(--port 8080)
+# Enable tool calls and parse reasoning responses by default
+ARGS=(--tool-call-parser openai --enable-auto-tool-choice --reasoning-parser openai_gptoss --port 8080)
 
 # Loop through all environment variables
 while IFS='=' read -r key value; do

--- a/OpenAI/gpt-oss/deploy/openai_gpt_oss.ipynb
+++ b/OpenAI/gpt-oss/deploy/openai_gpt_oss.ipynb
@@ -214,14 +214,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d960cc65",
+   "metadata": {},
+   "source": [
+    "#### Prerequisites\n",
+    "\n",
+    "To be able to build custom container images within SageMaker Studio, you'll first need to:\n",
+    "1. Enable Docker access in your Studio domain. See this [documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-local-get-started.html#studio-updated-local-enable) for details\n",
+    "2. Install Docker in your Studio environment. See this [link](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-local-get-started.html#studio-updated-local-docker-installation) for details"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1e93294b-e807-445e-8b79-85c7a91d4b5b",
    "metadata": {},
    "source": [
-    "#### Container preparation:\n",
-    "1. Enable Docker access in your Studio domain. Please see [documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-local-get-started.html#studio-updated-local-enable) for details\n",
-    "2. Install Docker in your Studion environment. See this [link](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-local-get-started.html#studio-updated-local-docker-installation) for details\n",
-    "3. Please modify `build.sh` to change the account_id, region, repository name, and tag if required\n",
-    "4. Build the image and push to ECR repository using `build.sh` in docker directory\n"
+    "#### Container preparation\n",
+    "\n",
+    "First, **modify** the below `build.sh` to configure your AWS account_id and region - and if needed customize the repository name and tag:"
    ]
   },
   {
@@ -235,7 +245,7 @@
     "export REGION=YOUR_REGION\n",
     "export ACCOUNT_ID=YOUR_ACCOUNT_ID\n",
     "export REPOSITORY_NAME=vllm\n",
-    "export TAG=v0.10.1\n",
+    "export TAG=v0.10.2\n",
     "\n",
     "full_name=\"${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${REPOSITORY_NAME}:${TAG}\"\n",
     "\n",
@@ -256,13 +266,30 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "3912170b",
+   "metadata": {},
+   "source": [
+    "Once you've set up your build script, un-comment and run the commands below to build and push the image:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "76af4d9f-8757-4d84-99f8-e8348ad015d6",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# !chmod u+x docker/build.sh\n",
     "# !cd docker; ./build.sh; cd .."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69d975b0",
+   "metadata": {},
+   "source": [
+    "With your custom container in Amazon ECR, you're ready to configure and deploy the model in SageMaker:"
    ]
   },
   {
@@ -275,10 +302,10 @@
     "#\n",
     "# Please make sure you are using the image that you pushed into ECR in a previous step\n",
     "#\n",
-    "inference_image = f\"{account_id}.dkr.ecr.{region}.amazonaws.com/vllm:v0.10.1\"\n",
+    "inference_image = f\"{account_id}.dkr.ecr.{region}.amazonaws.com/vllm:v0.10.2\"\n",
     "instance_type = \"ml.g6e.4xlarge\"\n",
     "num_gpu = 1\n",
-    "model_name = sagemaker.utils.name_from_base(\"model-byoc\")\n",
+    "model_name = sagemaker.utils.name_from_base(\"gpt-oss-byoc\")\n",
     "endpoint_name = model_name\n",
     "inference_component_name = f\"ic-{model_name}\"\n",
     "\n",
@@ -286,7 +313,7 @@
     "    \"OPTION_MODEL\": \"openai/gpt-oss-20b\",\n",
     "    \"OPTION_SERVED_MODEL_NAME\": \"model\",\n",
     "    \"OPTION_TENSOR_PARALLEL_SIZE\": json.dumps(num_gpu),\n",
-    "    #\"VLLM_ATTENTION_BACKEND\": \"TRITON_ATTN_VLLM_V1\", # not required for vLLM 0.10.1\n",
+    "    #\"VLLM_ATTENTION_BACKEND\": \"TRITON_ATTN_VLLM_V1\", # Not required for vLLM 0.10.1+\n",
     "    \"OPTION_ASYNC_SCHEDULING\": \"true\",\n",
     "}"
    ]
@@ -316,6 +343,8 @@
     "    inference_component_name=inference_component_name,\n",
     "    resources=ResourceRequirements(requests={\"num_accelerators\": num_gpu, \"memory\": 1024*3, \"copies\": 1,}),\n",
     ")\n",
+    "print(f\"Deployed endpoint name: {endpoint_name}\")\n",
+    "print(f\"Inference component name: {inference_component_name}\")\n",
     "\n",
     "llm = sagemaker.Predictor(\n",
     "    endpoint_name=endpoint_name,\n",


### PR DESCRIPTION
**Issue #, if available:** #120

**Description of changes:**

- Upgrade VLLM v0.10.1->0.10.2 to consume GPT-OSS-relevant updates as mentioned in the linked issue.
- Add tool-calling/parsing and reasoning-parsing arguments to VLLM by default in the provided serving script
    - Exposing them via the `OPTION_...` environment variables seemed unnecessary, and also I couldn't find a way to set `--enable-auto-tool-choice` (just a flag, no value) through this mechanism?
- Some minor notebook usability tweaks incl. using a more descriptive endpoint/model name, printing out the deployed endpoint & inference component name.

**Open questions:**

1. Is there a particular reason the image build shell commands are commented out in the notebook `# !cd docker...`? Shouldn't these be un-commented, since the later deployment cell will anyway error out if the image hasn't been built & staged?

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
