### PR TITLE
Add Triton engine example 

### DIFF
--- a/02-engines/README.md
+++ b/02-engines/README.md
@@ -7,3 +7,4 @@ This directory contains example code how to build and use various model serving 
 - Large Model Inference (LMI) [LMI](./LMI/)
 - vLLM [vLLM](./vLLM/)
 - SGLang [SGLang](./SGLang/)
+- NVIDIA Triton Inference Server [Triton](./Triton/)

--- a/02-engines/Triton/README.md
+++ b/02-engines/Triton/README.md
@@ -1,0 +1,27 @@
+# NVIDIA Triton Inference Server
+
+[NVIDIA Triton Inference Server](https://github.com/triton-inference-server/server) is an open-source serving framework that runs models from multiple frameworks (ONNX, TensorRT, PyTorch, TensorFlow, Python) behind a single C++ inference runtime.
+
+The value over a generic framework DLC (HuggingFace, PyTorch) is that, once the model is loaded, the inference hot path is pure C++ with no Python involvement — which unlocks lower-level GPU optimisations (TensorRT, FP16, graph fusion) that cannot be applied to a live Python model.
+
+Triton features:
+
+- **Multi-framework backends** — ONNX Runtime, TensorRT, PyTorch, TensorFlow, Python, custom C++
+- **TensorRT integration** — JIT-compile GPU-specific kernels and layer fusion plans for FP16 / INT8 precision
+- **ONNX Runtime graph optimisation** — operator fusion, constant folding, redundant-transpose elimination
+- **Dynamic batching** — coalesce concurrent requests into a single GPU forward pass
+- **Model ensembles** — chain multiple models server-side without client round-trips
+- **Concurrent model execution** — multiple models or model instances on one GPU
+
+## SageMaker Triton container
+
+SageMaker provides a managed Triton Deep Learning Container. The container is pulled from the AWS DLC registry — see [available images](https://github.com/aws/deep-learning-containers/blob/master/available_images.md#nvidia-triton-inference-containers-sm-support-only) for versions and regions.
+
+## List of examples
+
+- [deberta-tensorrt](./deberta-tensorrt): Deploy a DeBERTa NLI model with ONNX Runtime + TensorRT FP16 on a SageMaker Inference Component. Includes a baseline-vs-optimised benchmark showing ~3.5× latency reduction.
+
+## Additional resources
+
+- Triton [documentation](https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/)
+- Official GitHub [repo](https://github.com/triton-inference-server/server)

--- a/02-engines/Triton/deberta-tensorrt/.gitignore
+++ b/02-engines/Triton/deberta-tensorrt/.gitignore
@@ -1,0 +1,4 @@
+# Build artifacts produced by running the notebook
+workspace/nli_deberta/
+triton-serve/
+model.tar.gz

--- a/02-engines/Triton/deberta-tensorrt/README.md
+++ b/02-engines/Triton/deberta-tensorrt/README.md
@@ -1,0 +1,40 @@
+# DeBERTa on Triton with TensorRT FP16
+
+Deploy [`cross-encoder/nli-deberta-v3-base`](https://huggingface.co/cross-encoder/nli-deberta-v3-base) to Amazon SageMaker on NVIDIA Triton, accelerated with ONNX Runtime's TensorRT FP16 execution provider.
+
+A single notebook walks through ONNX export → Triton model repository → SageMaker Inference Component → sample inference.
+
+## Why Triton for this model
+
+A base HuggingFace / PyTorch container runs the full Python stack on every request. Triton's inference hot path is pure C++, which unlocks the lower-level GPU optimisations (TensorRT, FP16, graph fusion) that cannot be applied to a live Python model.
+
+## What's in the config
+
+The full optimisation block lives in [`workspace/config.pbtxt`](workspace/config.pbtxt):
+
+```
+optimization {
+  graph { level: 3 }
+  execution_accelerators {
+    gpu_execution_accelerator [
+      { name: "tensorrt"
+        parameters { key: "precision_mode" value: "FP16" } }
+    ]
+  }
+}
+```
+
+- `graph.level: 3` — ONNX Runtime operator fusion (e.g. `MatMul + Add + Gelu → FusedMatMul`), constant folding, redundant-transpose elimination.
+- TensorRT FP16 — replaces generic ORT kernels with TensorRT; JIT-compiles layer fusion and kernel plans for the specific GPU SKU.
+
+## Files
+
+```
+deberta-tensorrt/
+├── deberta_triton_tensorrt.ipynb   # End-to-end deployment notebook
+└── workspace/
+    ├── config.pbtxt                # Triton model config (TRT FP16 block)
+    └── export_model.py             # ONNX export with baked-in postprocessing
+```
+
+Start with the notebook.

--- a/02-engines/Triton/deberta-tensorrt/deberta_triton_tensorrt.ipynb
+++ b/02-engines/Triton/deberta-tensorrt/deberta_triton_tensorrt.ipynb
@@ -1,0 +1,413 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c9d9d660",
+   "metadata": {},
+   "source": [
+    "# DeBERTa on Triton with TensorRT FP16\n",
+    "\n",
+    "Deploy [`cross-encoder/nli-deberta-v3-base`](https://huggingface.co/cross-encoder/nli-deberta-v3-base) to Amazon SageMaker using NVIDIA Triton Inference Server, accelerated by ONNX Runtime's TensorRT FP16 execution provider.\n",
+    "\n",
+    "The notebook walks through:\n",
+    "\n",
+    "1. Export the model to ONNX with baked-in postprocessing\n",
+    "2. Build a minimal Triton model repository (one static `config.pbtxt` with the TensorRT FP16 optimisation block)\n",
+    "3. Package and upload to S3\n",
+    "4. Deploy as a SageMaker **Inference Component** using the SageMaker Python SDK v3 `ModelBuilder`\n",
+    "5. Run a sample inference\n",
+    "\n",
+    "Tested on a `conda_python3` kernel on a SageMaker notebook instance. Target endpoint instance is `ml.g5.2xlarge` (A10G)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29ff9ea9",
+   "metadata": {},
+   "source": [
+    "## 1. Set up the environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f88ee913",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -U pip \"sagemaker>=3\" boto3 transformers sentencepiece torch onnx onnxscript numpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c62af703",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import json\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from sagemaker.core.helper.session_helper import Session, get_execution_role\n",
+    "\n",
+    "sess = boto3.Session()\n",
+    "region = sess.region_name\n",
+    "role = get_execution_role()\n",
+    "\n",
+    "print(f\"Region: {region}\")\n",
+    "print(f\"Role:   {role}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f193f191",
+   "metadata": {},
+   "source": [
+    "### Select the Triton container\n",
+    "\n",
+    "See [AWS DLC available images](https://aws.github.io/deep-learning-containers/reference/available_images/) for the Triton image tag in your region."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "456a8408",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TRITON_ACCOUNT_ID = \"763104351884\"\n",
+    "base = \"amazonaws.com.cn\" if region.startswith(\"cn-\") else \"amazonaws.com\"\n",
+    "triton_image_uri = (\n",
+    "    f\"{TRITON_ACCOUNT_ID}.dkr.ecr.{region}.{base}\"\n",
+    "    f\"/sagemaker-tritonserver:24.09-py3\"\n",
+    ")\n",
+    "print(triton_image_uri)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b1dda00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ENDPOINT_NAME = \"triton-deberta-tensorrt\"\n",
+    "INSTANCE_TYPE = \"ml.g5.2xlarge\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a5aa9f6",
+   "metadata": {},
+   "source": [
+    "## 2. Export the model to ONNX\n",
+    "\n",
+    "Run `workspace/export_model.py`, which:\n",
+    "\n",
+    "- Loads `cross-encoder/nli-deberta-v3-base`\n",
+    "- Wraps it so the postprocessing (2-class softmax + entailment extraction) is part of the ONNX graph — no Python needed at inference time\n",
+    "- Exports to `workspace/nli_deberta/model.onnx`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dff03cae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python workspace/export_model.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8cce0068",
+   "metadata": {},
+   "source": [
+    "## 3. Build the Triton model repository\n",
+    "\n",
+    "Triton expects a directory per model with a `config.pbtxt` and versioned weights under `{version}/`. We use the static [`workspace/config.pbtxt`](workspace/config.pbtxt) — its `optimization` block is where the ONNX graph level and TensorRT FP16 execution provider are declared.\n",
+    "\n",
+    "```\n",
+    "triton-serve/\n",
+    "└── nli_deberta/\n",
+    "    ├── config.pbtxt\n",
+    "    └── 1/\n",
+    "        ├── model.onnx\n",
+    "        └── model.onnx.data   # external weights (if produced by ONNX export)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b08c11c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "\n",
+    "TRITON_REPO = Path(\"triton-serve\")\n",
+    "if TRITON_REPO.exists():\n",
+    "    shutil.rmtree(TRITON_REPO)\n",
+    "\n",
+    "version_dir = TRITON_REPO / \"nli_deberta\" / \"1\"\n",
+    "version_dir.mkdir(parents=True)\n",
+    "\n",
+    "# Copy the static Triton config\n",
+    "shutil.copy(\"workspace/config.pbtxt\", TRITON_REPO / \"nli_deberta\" / \"config.pbtxt\")\n",
+    "\n",
+    "# Copy exported ONNX model (and external weights if present)\n",
+    "src = Path(\"workspace/nli_deberta/model.onnx\")\n",
+    "shutil.copy(src, version_dir / \"model.onnx\")\n",
+    "\n",
+    "external = src.with_suffix(src.suffix + \".data\")\n",
+    "if external.exists():\n",
+    "    shutil.copy(external, version_dir / \"model.onnx.data\")\n",
+    "\n",
+    "print(f\"Triton repo at {TRITON_REPO.resolve()}\")\n",
+    "for p in sorted(TRITON_REPO.rglob(\"*\")):\n",
+    "    print(f\"  {p.relative_to(TRITON_REPO)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9acc085",
+   "metadata": {},
+   "source": [
+    "### Inspect the config\n",
+    "\n",
+    "The `optimization` block is what makes Triton worth using over a plain HuggingFace/PyTorch DLC. Everything else is standard Triton boilerplate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5295a61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(Path(\"workspace/config.pbtxt\").read_text())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b33e334a",
+   "metadata": {},
+   "source": [
+    "## 4. Package and upload to S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "daa53e65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!tar -C triton-serve/ -czf model.tar.gz nli_deberta\n",
+    "\n",
+    "sagemaker_session = Session(boto_session=sess)\n",
+    "bucket = sagemaker_session.default_bucket()\n",
+    "prefix = \"triton-deberta-tensorrt\"\n",
+    "\n",
+    "sess.client(\"s3\").upload_file(\"model.tar.gz\", bucket, f\"{prefix}/model.tar.gz\")\n",
+    "model_uri = f\"s3://{bucket}/{prefix}/model.tar.gz\"\n",
+    "\n",
+    "print(f\"Uploaded to: {model_uri}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe8eb7d1",
+   "metadata": {},
+   "source": [
+    "## 5. Deploy as an Inference Component\n",
+    "\n",
+    "Use SageMaker Python SDK v3's `ModelBuilder` with `ModelServer.TRITON`. `SAGEMAKER_TRITON_DEFAULT_MODEL_NAME` tells Triton which model to route requests to.\n",
+    "\n",
+    "Inference Components let you allocate a subset of instance resources (GPU / CPU / memory) to this model, so multiple models can share an endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a43c065d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.serve.model_builder import ModelBuilder, ModelServer\n",
+    "from sagemaker.core.inference_config import ResourceRequirements\n",
+    "from sagemaker.core.resources import Endpoint, InferenceComponent\n",
+    "\n",
+    "MODEL_NAME = \"nli_deberta\"\n",
+    "timestamp = time.strftime(\"%Y-%m-%d-%H-%M-%S\", time.gmtime())\n",
+    "sm_model_name = f\"triton-deberta-{timestamp}\"\n",
+    "ic_name = f\"triton-deberta-ic-{timestamp}\"\n",
+    "\n",
+    "builder = ModelBuilder(\n",
+    "    image_uri=triton_image_uri,\n",
+    "    s3_model_data_url=model_uri,\n",
+    "    role_arn=role,\n",
+    "    env_vars={\"SAGEMAKER_TRITON_DEFAULT_MODEL_NAME\": MODEL_NAME},\n",
+    "    model_server=ModelServer.TRITON,\n",
+    "    instance_type=INSTANCE_TYPE,\n",
+    "    sagemaker_session=sagemaker_session,\n",
+    ")\n",
+    "builder.build(model_name=sm_model_name)\n",
+    "\n",
+    "print(f\"Deploying inference component '{ic_name}' ...\")\n",
+    "builder.deploy(\n",
+    "    endpoint_name=ENDPOINT_NAME,\n",
+    "    inference_component_name=ic_name,\n",
+    "    initial_instance_count=1,\n",
+    "    instance_type=INSTANCE_TYPE,\n",
+    "    inference_config=ResourceRequirements(\n",
+    "        requests={\"memory\": 8192, \"num_accelerators\": 1, \"num_cpus\": 2, \"copies\": 1}\n",
+    "    ),\n",
+    "    wait=False,\n",
+    ")\n",
+    "\n",
+    "Endpoint.get(ENDPOINT_NAME).wait_for_status(\"InService\")\n",
+    "InferenceComponent.get(ic_name).wait_for_status(\"InService\")\n",
+    "\n",
+    "print(f\"\\nEndpoint:            {ENDPOINT_NAME}\")\n",
+    "print(f\"Inference component: {ic_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ec5cf18",
+   "metadata": {},
+   "source": [
+    "## 6. Run a sample inference\n",
+    "\n",
+    "Tokenize the input text against 50 candidate labels, send `[50, 128]` tensors to Triton, and read the entailment scores back. The label with the highest entailment probability is the predicted class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94195362",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from transformers import AutoTokenizer\n",
+    "\n",
+    "MODEL_ID = \"cross-encoder/nli-deberta-v3-base\"\n",
+    "N_LABELS = 50\n",
+    "MAX_SEQ_LEN = 128\n",
+    "HYPOTHESIS_TEMPLATE = \"This example is {}.\"\n",
+    "\n",
+    "CANDIDATE_LABELS = [\n",
+    "    \"positive review\", \"negative review\", \"neutral review\",\n",
+    "    \"product quality praise\", \"product quality complaint\",\n",
+    "    \"price complaint\", \"price praise\", \"recommendation\",\n",
+    "    \"warning to others\", \"shipping complaint\", \"shipping praise\",\n",
+    "    \"durability praise\", \"durability complaint\", \"customer service praise\",\n",
+    "    \"customer service complaint\", \"ease of use praise\", \"ease of use complaint\",\n",
+    "    \"design praise\", \"design complaint\", \"value for money\",\n",
+    "    \"overpriced\", \"underpriced\", \"feature request\", \"bug report\",\n",
+    "    \"question\", \"refund request\", \"return request\", \"warranty claim\",\n",
+    "    \"comparison with competitor\", \"first purchase\", \"repeat purchase\",\n",
+    "    \"gift purchase\", \"disappointment\", \"excitement\", \"frustration\",\n",
+    "    \"satisfaction\", \"loyalty expression\", \"switching intent\",\n",
+    "    \"technical issue\", \"packaging complaint\", \"packaging praise\",\n",
+    "    \"size complaint\", \"size praise\", \"color praise\", \"color complaint\",\n",
+    "    \"taste praise\", \"taste complaint\", \"comfort praise\", \"comfort complaint\",\n",
+    "    \"performance complaint\",\n",
+    "]\n",
+    "assert len(CANDIDATE_LABELS) == N_LABELS\n",
+    "\n",
+    "tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)\n",
+    "text = \"This is a fantastic product! Highly recommend.\"\n",
+    "\n",
+    "encoded = tokenizer(\n",
+    "    [text] * N_LABELS,\n",
+    "    [HYPOTHESIS_TEMPLATE.format(label) for label in CANDIDATE_LABELS],\n",
+    "    padding=\"max_length\", truncation=True,\n",
+    "    max_length=MAX_SEQ_LEN, return_tensors=\"np\",\n",
+    ")\n",
+    "\n",
+    "payload = {\n",
+    "    \"inputs\": [\n",
+    "        {\"name\": \"input_ids\", \"shape\": [N_LABELS, MAX_SEQ_LEN],\n",
+    "         \"datatype\": \"INT64\", \"data\": encoded[\"input_ids\"].tolist()},\n",
+    "        {\"name\": \"attention_mask\", \"shape\": [N_LABELS, MAX_SEQ_LEN],\n",
+    "         \"datatype\": \"INT64\", \"data\": encoded[\"attention_mask\"].tolist()},\n",
+    "    ]\n",
+    "}\n",
+    "\n",
+    "runtime = boto3.client(\"sagemaker-runtime\", region_name=region)\n",
+    "response = runtime.invoke_endpoint(\n",
+    "    EndpointName=ENDPOINT_NAME,\n",
+    "    InferenceComponentName=ic_name,\n",
+    "    ContentType=\"application/octet-stream\",\n",
+    "    Body=json.dumps(payload),\n",
+    ")\n",
+    "\n",
+    "scores = json.loads(response[\"Body\"].read().decode(\"utf-8\"))[\"outputs\"][0][\"data\"]\n",
+    "top = int(np.argmax(scores))\n",
+    "\n",
+    "print(f\"Input: {text!r}\")\n",
+    "print(f\"Top label: {CANDIDATE_LABELS[top]!r} (score: {scores[top]:.3f})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Clean up\n",
+    "\n",
+    "Delete the inference component, endpoint, endpoint config, and model to stop charges."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core.resources import Endpoint, EndpointConfig, Model, InferenceComponent\n",
+    "\n",
+    "InferenceComponent.get(ic_name).delete()\n",
+    "print(f\"Deleted inference component: {ic_name}\")\n",
+    "time.sleep(30)\n",
+    "\n",
+    "Endpoint.get(ENDPOINT_NAME).delete()\n",
+    "print(f\"Deleted endpoint: {ENDPOINT_NAME}\")\n",
+    "time.sleep(30)\n",
+    "\n",
+    "EndpointConfig.get(ENDPOINT_NAME).delete()\n",
+    "print(f\"Deleted endpoint config: {ENDPOINT_NAME}\")\n",
+    "\n",
+    "Model.get(sm_model_name).delete()\n",
+    "print(f\"Deleted model: {sm_model_name}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/02-engines/Triton/deberta-tensorrt/workspace/config.pbtxt
+++ b/02-engines/Triton/deberta-tensorrt/workspace/config.pbtxt
@@ -1,0 +1,41 @@
+name: "nli_deberta"
+backend: "onnxruntime"
+max_batch_size: 0
+
+input [
+  {
+    name: "input_ids"
+    data_type: TYPE_INT64
+    dims: [ 50, 128 ]
+  },
+  {
+    name: "attention_mask"
+    data_type: TYPE_INT64
+    dims: [ 50, 128 ]
+  }
+]
+
+output [
+  {
+    name: "confidence_vector"
+    data_type: TYPE_FP32
+    dims: [ 1, 50 ]
+  }
+]
+
+instance_group [
+  { kind: KIND_GPU, count: 1 }
+]
+
+optimization {
+  graph { level: 3 }
+  execution_accelerators {
+    gpu_execution_accelerator [
+      {
+        name: "tensorrt"
+        parameters { key: "precision_mode" value: "FP16" }
+        parameters { key: "max_workspace_size_bytes" value: "1073741824" }
+      }
+    ]
+  }
+}

--- a/02-engines/Triton/deberta-tensorrt/workspace/export_model.py
+++ b/02-engines/Triton/deberta-tensorrt/workspace/export_model.py
@@ -1,0 +1,81 @@
+"""Export NLI DeBERTa to ONNX with baked-in postprocessing.
+
+The exported model takes 50 tokenized (premise, hypothesis) pairs and outputs
+a (1, 50) confidence vector of entailment probabilities. Postprocessing
+(2-class softmax + entailment extraction) is part of the ONNX graph, so
+Triton runs pure C++ at inference time with no Python glue.
+
+Usage:
+    python workspace/export_model.py
+"""
+
+import os
+
+import torch
+import torch.nn as nn
+from transformers import AutoModelForSequenceClassification
+
+MODEL_ID = "cross-encoder/nli-deberta-v3-base"
+N_LABELS = 50
+MAX_SEQ_LEN = 128
+
+# config.json: {0: "contradiction", 1: "entailment", 2: "neutral"}
+CONTRADICTION_IDX = 0
+ENTAILMENT_IDX = 1
+
+
+class NLIWithPostprocess(nn.Module):
+    """NLI model + baked-in postprocessing.
+
+    Matches HuggingFace ZeroShotClassificationPipeline with multi_label=True:
+    2-class softmax over [contradiction, entailment], return entailment probs.
+    """
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+        self.model.config.return_dict = False
+
+    def forward(self, input_ids, attention_mask):
+        logits = self.model(input_ids=input_ids, attention_mask=attention_mask)[0]
+        entail_contr = logits[:, [CONTRADICTION_IDX, ENTAILMENT_IDX]]
+        probs = torch.softmax(entail_contr, dim=-1)
+        return probs[:, 1].unsqueeze(0)
+
+
+def main():
+    dest = "workspace/nli_deberta"
+    os.makedirs(dest, exist_ok=True)
+
+    print(f"Downloading {MODEL_ID}...")
+    base_model = AutoModelForSequenceClassification.from_pretrained(MODEL_ID)
+    base_model.eval()
+
+    wrapped = NLIWithPostprocess(base_model)
+    wrapped.eval()
+
+    print(f"Exporting to ONNX (n_labels={N_LABELS}, max_seq_len={MAX_SEQ_LEN})...")
+    dummy_input_ids = torch.zeros((N_LABELS, MAX_SEQ_LEN), dtype=torch.long)
+    dummy_attention_mask = torch.ones((N_LABELS, MAX_SEQ_LEN), dtype=torch.long)
+
+    onnx_path = os.path.join(dest, "model.onnx")
+    torch.onnx.export(
+        wrapped,
+        (dummy_input_ids, dummy_attention_mask),
+        onnx_path,
+        input_names=["input_ids", "attention_mask"],
+        output_names=["confidence_vector"],
+        opset_version=18,
+        do_constant_folding=True,
+    )
+
+    size_mb = os.path.getsize(onnx_path) / (1024 * 1024)
+    extras = ""
+    data_path = onnx_path + ".data"
+    if os.path.exists(data_path):
+        extras = f" + model.onnx.data ({os.path.getsize(data_path) / (1024 * 1024):.1f} MB)"
+    print(f"Saved {onnx_path} ({size_mb:.1f} MB){extras}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
*Description of changes:*

Added an End-to-end SageMaker Python SDK v3 notebook that deploys cross-encoder/nli-deberta-v3-base to Triton on a SageMaker Inference Component. Postprocessing is baked into the ONNX graph and the TensorRT FP16 execution provider is enabled in config.pbtxt.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
