### PR TITLE
Migrate 07-benchmark suite to SageMaker SDK v3

### DIFF
--- a/07-benchmark/sagemaker-inference-benchmark-suite/requirements.txt
+++ b/07-benchmark/sagemaker-inference-benchmark-suite/requirements.txt
@@ -1,6 +1,6 @@
 boto3>=1.35.0
 botocore>=1.35.0
-sagemaker>=2.232.0
+sagemaker>=3.0.0
 pyyaml>=6.0
 textual>=3.0.0
 rich>=13.0.0

--- a/07-benchmark/sagemaker-inference-benchmark-suite/run.py
+++ b/07-benchmark/sagemaker-inference-benchmark-suite/run.py
@@ -107,7 +107,8 @@ Standalone (no config needed):
     parser.add_argument("--ic", default=None,
                         help="Inference Component name")
     parser.add_argument("--role", default=None, help="IAM role ARN")
-    parser.add_argument("--region", default="us-west-2", help="AWS region")
+    parser.add_argument("--region", default=None,
+                        help="AWS region (overrides recipe; falls back to us-west-2 for standalone commands)")
     parser.add_argument("--pattern", default=None,
                         choices=["standard", "inference_component"],
                         help="Deployment pattern")
@@ -162,7 +163,8 @@ Standalone (no config needed):
 
     if args.status:
         from scripts.deployer import list_endpoints
-        regions = [args.region] if args.region != "all" else ["us-west-2", "us-east-1"]
+        region = args.region or "us-west-2"
+        regions = [region] if region != "all" else ["us-west-2", "us-east-1"]
         for r in regions:
             list_endpoints(r, args.prefix)
         return 0
@@ -179,7 +181,7 @@ Standalone (no config needed):
             print("Error: --endpoint required for standalone cleanup.")
             return 1
         from scripts.deployer import cleanup
-        cleanup(args.endpoint, args.region, args.pattern or "standard")
+        cleanup(args.endpoint, args.region or "us-west-2", args.pattern or "standard")
         return 0
 
     # ================================================================

--- a/07-benchmark/sagemaker-inference-benchmark-suite/scripts/deployer.py
+++ b/07-benchmark/sagemaker-inference-benchmark-suite/scripts/deployer.py
@@ -263,34 +263,54 @@ def list_endpoints(region: str, name_prefix: str = None):
 
 def _deploy_standard(config: BenchmarkConfig, image_uri: str,
                      env: dict, endpoint_name: str) -> DeploymentResult:
-    """Deploy using SageMaker SDK Model.deploy() — standard pattern."""
-    import sagemaker
-    from sagemaker.model import Model
-    from sagemaker.predictor import Predictor
-    from sagemaker.serializers import JSONSerializer
+    """Deploy using SageMaker SDK v3 sagemaker.core.resources — standard pattern.
+
+    Artifact-less BYOC: the container fetches the model at startup via env vars
+    (e.g., SM_VLLM_MODEL, HF_MODEL_ID), so there is no model_data_url to upload.
+    Uses sagemaker.core.resources.Model/EndpointConfig/Endpoint, the v3 mapping
+    for the boto3 CreateModel/CreateEndpointConfig/CreateEndpoint calls.
+    """
+    from sagemaker.core.resources import Endpoint, EndpointConfig, Model
+    from sagemaker.core.shapes import ContainerDefinition, ProductionVariant
 
     d = config.deployment
     region = d.endpoint.region
-
     boto_session = boto3.Session(region_name=region)
-    sm_session = sagemaker.Session(boto_session=boto_session)
 
-    model = Model(
-        image_uri=image_uri,
-        role=d.endpoint.role_arn,
-        predictor_cls=Predictor,
-        env=env,
-        sagemaker_session=sm_session,
-    )
+    model_name = f"mdl-{endpoint_name}"[:63]
+    epc_name = f"epc-{endpoint_name}"[:63]
 
     try:
-        model.deploy(
-            instance_type=d.instance.type,
-            initial_instance_count=d.instance.count,
-            endpoint_name=endpoint_name,
-            container_startup_health_check_timeout=d.endpoint.health_check_timeout,
-            serializer=JSONSerializer(),
+        Model.create(
+            model_name=model_name,
+            primary_container=ContainerDefinition(image=image_uri, environment=env),
+            execution_role_arn=d.endpoint.role_arn,
+            session=boto_session,
+            region=region,
         )
+        EndpointConfig.create(
+            endpoint_config_name=epc_name,
+            production_variants=[ProductionVariant(
+                variant_name="AllTraffic",
+                model_name=model_name,
+                instance_type=d.instance.type,
+                initial_instance_count=d.instance.count,
+                container_startup_health_check_timeout_in_seconds=d.endpoint.health_check_timeout,
+            )],
+            session=boto_session,
+            region=region,
+        )
+        Endpoint.create(
+            endpoint_name=endpoint_name,
+            endpoint_config_name=epc_name,
+            session=boto_session,
+            region=region,
+        )
+
+        if not wait_for_endpoint(endpoint_name, region,
+                                  timeout_sec=d.endpoint.health_check_timeout):
+            return DeploymentResult(endpoint_name, None, False, region, 0)
+
         print(f"\nEndpoint deployed: {endpoint_name}")
         return DeploymentResult(
             endpoint_name=endpoint_name, ic_name=None,


### PR DESCRIPTION
## Summary

Fixes a deploy failure in `07-benchmark/sagemaker-inference-benchmark-suite/` introduced when SageMaker Python SDK v3.0 dropped the legacy `sagemaker.model.Model` / `sagemaker.predictor.Predictor` / `sagemaker.Session` interfaces.

A fresh `pip install -r requirements.txt` in SageMaker Studio (or any clean env) now resolves to SDK v3, and the standard deploy path errors out:

```
File "scripts/deployer.py", line 268, in _deploy_standard
    from sagemaker.model import Model
ModuleNotFoundError: No module named 'sagemaker.model'
```

Reported by Dmitry Soldatkin. Also fixes a region-override bug where the YAML recipe's `endpoint.region` was silently clobbered by the argparse default `"us-west-2"`.

## Changes

- **`requirements.txt`**: `sagemaker>=2.232.0` → `sagemaker>=3.0.0`
- **`scripts/deployer.py:_deploy_standard`**: rewrite using v3 `sagemaker.core.resources.Model / EndpointConfig / Endpoint`. The IC pattern path (`_deploy_ic`) was already pure boto3 and is untouched. `sagemaker.serve.ModelBuilder` was evaluated but is artifact-centric (tries to upload a synthesized model artifact even when none exists), which doesn't fit our artifact-less BYOC use case where the vLLM container fetches the HF model at startup via env vars.
- **`run.py`**: `--region` default changed from `"us-west-2"` to `None` so the YAML recipe's `endpoint.region` is no longer overwritten by the argparse default. Standalone commands (`--status`, `--cleanup`) fall back to `"us-west-2"` when no region is provided.

All public CLI flags and README examples remain identical.

## Test plan

End-to-end verified on us-west-2 with the same recipe Dmitry hit the bug on:

- [x] Imports: `from sagemaker.model import Model` raises ImportError on v3 (confirmed); `from sagemaker.core.resources import Model, EndpointConfig, Endpoint` resolves cleanly.
- [x] Region override (dry-run): editing recipe to `region: us-east-2` now produces a `us-east-2` container URI (was `us-west-2` before the fix).
- [x] Deploy: `python run.py -f recipes/qwen3-32b-g5-vanilla.yaml --only deploy --no-test --role <ROLE>` → endpoint reached InService on `ml.g5.12xlarge` (~31 min, mostly model weight download / vLLM 4-way TP init).
- [x] Benchmark: `--only benchmark --endpoint <NAME> --use-case multiturn_chat --concurrency 1,4 --requests 5` → 2/2 levels successful, output_validation_rate=100%, TTFT p50=146ms (C=1) / 338ms (C=4), tok/s ~22.
- [x] TUI: `python run.py --tui` mounts under headless test harness, tab navigation works.
- [x] Cleanup: `python run.py --cleanup --endpoint <NAME>` removes endpoint + endpoint config + model.