### PR TITLE
autobench initial commit

### DIFF
--- a/07-benchmark/autobench/README.md
+++ b/07-benchmark/autobench/README.md
@@ -126,6 +126,39 @@ All scripts support `--help` for full usage. Common flags:
 --cleanup           # Delete deployed resources
 ```
 
+### Backfill Options
+
+Re-process historical benchmark results from S3 tarballs:
+
+```bash
+# Backfill all models for an environment
+python backfill.py --environment=managed-inference
+
+# Backfill a specific model
+python backfill.py --environment=hyperpod --model=deepseek-v4-pro-vllm
+
+# Only process results from a specific date onward
+python backfill.py --environment=hyperpod --since=20260527
+
+# Only keep the latest run per (workload × concurrency) — skips old/failed runs
+python backfill.py --environment=hyperpod --latest-only
+
+# Combine both: latest results from this week only
+python backfill.py --environment=managed-inference --latest-only --since=20260525
+
+# Preview without writing
+python backfill.py --environment=hyperpod --dry-run
+```
+
+| Flag | Effect |
+|------|--------|
+| `--since YYYYMMDD[THHMMSS]` | Only process tarballs with path timestamp ≥ this value |
+| `--latest-only` | For each (workload, concurrency) combo, only process the most recent tarball |
+| `--dry-run` | Preview what would be written without writing to Athena |
+| `--model` | Filter to a specific model key |
+| `--config` | Path to benchmarks.yaml (default: ../benchmarks.yaml) |
+
+
 ## Infrastructure
 
 For automated HyperPod cluster setup with pre-configured networking (security groups, NLB subnet tags, IRSA), see [`infra/hyperpod-cluster-bootstrap.yaml`](infra/hyperpod-cluster-bootstrap.yaml).

--- a/07-benchmark/autobench/README.md
+++ b/07-benchmark/autobench/README.md
@@ -1,0 +1,159 @@
+# SageMaker GenAI Inference Benchmarking
+
+Configuration-driven LLM inference benchmarking across SageMaker Managed Inference, HyperPod EKS, and Bedrock BYOM. One config file drives all execution paths.
+
+## Architecture
+
+```
+benchmarks.yaml (single source of truth)
+       │
+       ├── sdk/download_models.py         → Stage weights from HuggingFace to S3
+       ├── sdk/benchmark.py               → SageMaker Managed Inference (FTP/reserved capacity)
+       ├── sdk/benchmark_hyperpod.py      → HyperPod EKS (kubectl + direct-URL)
+       └── sdk/benchmark_bedrock_byom.py  → Bedrock BYOM (Mantle API + RU reservations)
+```
+
+All paths use **SageMaker AI Benchmarking (NVIDIA AIPerf)** as the load generator.
+
+## Quick Start
+
+```bash
+cd sdk
+uv venv && source .venv/bin/activate
+uv pip install -r requirements.txt
+
+# 1. Copy and configure
+cp benchmarks.yaml.example benchmarks.yaml
+# Edit benchmarks.yaml with your account ID, region, role ARN, etc.
+
+# 2. Stage model weights to S3
+python download_models.py --submit --region us-east-2 --model=gemma
+
+# 3. Update s3_model_uri in benchmarks.yaml with the printed URI
+
+# 4. Run benchmarks
+python benchmark.py --model=gemma              # SageMaker MI
+python benchmark_hyperpod.py --model=gemma     # HyperPod EKS
+python benchmark_bedrock_byom.py --model=gemma # Bedrock BYOM
+```
+
+## Execution Paths
+
+| Path | Script | Deploy Method | Compute |
+|------|--------|---------------|---------|
+| **SageMaker MI** | `benchmark.py` | `create_model` → endpoint | FTP reserved capacity |
+| **HyperPod EKS** | `benchmark_hyperpod.py` | `kubectl apply` → NLB | FTP node group |
+| **Bedrock BYOM** | `benchmark_bedrock_byom.py` | Mantle API import + RU reservation | AWS-managed |
+
+## Configuration
+
+All configuration lives in `benchmarks.yaml`. See [`benchmarks.yaml.example`](benchmarks.yaml.example) for a complete template with all features documented.
+
+### Key Sections
+
+| Section | Purpose |
+|---------|---------|
+| `athena` | Central results bucket + region |
+| `workloads` | Business use cases → benchmark parameters |
+| `models` | Model definitions shared across all paths |
+| `sagemaker_defaults` + `sagemaker_benchmarks` | SMAI-specific config |
+| `hyperpod_defaults` + `hyperpod_benchmarks` | HyperPod-specific config |
+| `byom_defaults` + `byom_benchmarks` | Bedrock BYOM-specific config |
+
+### Model Config Structure
+
+Models are defined once and shared across all three paths:
+
+```yaml
+models:
+  my-model-vllm:
+    model_name: org/Model-Name        # HuggingFace ID
+    instance_type: ml.p6-b200.48xlarge
+    num_gpus: 8
+    s3_model_uri: "s3://..."          # Pre-staged weights
+    env:                               # SMAI: SM_VLLM_* env vars
+      SM_VLLM_KV_CACHE_DTYPE: "fp8"
+    hyperpod_args:                     # HyperPod: vLLM CLI args
+      - "--kv-cache-dtype"
+      - "fp8"
+    hyperpod_env:                      # HyperPod: pod env vars
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    byom:                              # Bedrock BYOM: import config
+      base_model_id: "provider.model"
+      model_id: ""                     # filled after import
+```
+
+## Results Pipeline
+
+Results flow to a central Athena table for cross-model, cross-platform analysis:
+
+```
+S3 (AIPerf tar.gz) → athena_writer.py (extract + enrich) → S3 (Hive-partitioned JSON) → Athena → QuickSight
+```
+
+Each result row is **self-describing** — includes serving config, vLLM version, dataset, error rate, and a full raw AIPerf JSON blob for ad-hoc queries.
+
+### Athena Setup
+
+```bash
+# Create the table (run in Athena console)
+# See sdk/athena_ddl.sql for the full DDL
+
+# After benchmarks complete, discover new partitions:
+MSCK REPAIR TABLE benchmarking.benchmark_metrics;
+```
+
+### Backfill
+
+Re-process existing results with the latest schema:
+
+```bash
+python backfill.py --environment=managed-inference
+python backfill.py --environment=hyperpod --model=gemma-4-31b-vllm
+```
+
+## CLI Reference
+
+All scripts support `--help` for full usage. Common flags:
+
+```bash
+--validate          # Show expanded job matrix (no AWS calls)
+--model=<substr>    # Filter by model key (substring match)
+--workload=<substr> # Filter by workload key (substring match)
+--submit            # Submit as unattended Processing Job (5-day timeout)
+--deploy-only       # Deploy endpoints/pods only (no benchmark)
+--benchmark-only    # Benchmark existing endpoints/pods
+--cleanup           # Delete deployed resources
+```
+
+## Infrastructure
+
+For automated HyperPod cluster setup with pre-configured networking (security groups, NLB subnet tags, IRSA), see [`infra/hyperpod-cluster-bootstrap.yaml`](infra/hyperpod-cluster-bootstrap.yaml).
+
+## Key Features
+
+- **Resume-safe** — re-run safely; completed jobs are skipped automatically
+- **Gap capture** — failures classified into actionable categories
+- **Set-and-forget** — `--submit` runs as Processing Job (5-day timeout, no credential expiry)
+- **Single config** — `benchmarks.yaml` drives all paths
+- **S3-first model loading** — pre-stage weights to avoid deploy timeouts
+- **Centralized results** — athena_writer pushes all results to one region
+- **Self-describing records** — every Athena row includes full serving context + config hash
+- **Deterministic deduplication** — re-runs overwrite previous results (no duplicates)
+
+## Extending
+
+### Add a New Model
+
+1. Add to `models` in `benchmarks.yaml`
+2. Add to the appropriate `*_benchmarks` section
+3. Stage weights: `python download_models.py --submit --region <region> --model=<key>`
+4. Run: `python benchmark.py --model=<key>`
+
+### Add a New Workload
+
+Add to `workloads` in `benchmarks.yaml`, then reference in benchmark entries.
+
+### Change vLLM Version
+
+Update `sagemaker_image` in `sagemaker_defaults` (SMAI) and/or `vllm_image` in `hyperpod_defaults` (HyperPod).

--- a/07-benchmark/autobench/benchmarks.yaml.example
+++ b/07-benchmark/autobench/benchmarks.yaml.example
@@ -1,0 +1,238 @@
+# =============================================================================
+# SageMaker GenAI Inference Benchmarking — Configuration Template
+# =============================================================================
+# Copy this file to benchmarks.yaml and fill in your values.
+# This single config drives all three execution paths (SMAI, HyperPod, BYOM).
+#
+# Architecture:
+#   workloads   → named profiles mapping business use cases to benchmark parameters
+#   models      → model + instance + serving engine combinations (shared across paths)
+#   *_defaults  → path-specific defaults (SMAI, HyperPod, BYOM)
+#   *_benchmarks → which workloads to run against which models per path
+
+# ---------------------------------------------------------------------------
+# Central Results (Athena)
+# ---------------------------------------------------------------------------
+# All results are written to a central S3 prefix for Athena/QuickSight analysis.
+athena:
+  bucket: sagemaker-benchmark-<REGION>-<ACCOUNT_ID>
+  region: <REGION>
+  prefix: athena/results
+
+# ---------------------------------------------------------------------------
+# Workload Profiles
+# ---------------------------------------------------------------------------
+# Each workload maps a business use case to concrete benchmark dimensions.
+# These are opinionated, documented, and defensible configurations.
+
+workloads:
+  multi_turn_chat:
+    description: "Conversations with 1-10 rounds of back-and-forth. Copilots, virtual assistants, customer support."
+    input_tokens: 500
+    output_tokens: 500
+    concurrency: [1, 4, 8, 16, 32, 64]
+    streaming: true
+    dataset: blazedit_10k
+    duration: 300
+    warmup: 30
+
+  rag_document_qa:
+    description: "Documents from 2K-10K tokens injected as context. Enterprise knowledge bases, legal & medical search."
+    input_tokens: 5000
+    output_tokens: 500
+    concurrency: [1, 4, 8, 16, 32]
+    streaming: true
+    dataset: blazedit_10k
+    duration: 300
+    warmup: 30
+
+  agent_tool_calling:
+    description: "Multi-step agents with 5-10 tool calls per session. Coding agents, research agents, workflow automation."
+    input_tokens: 1000
+    output_tokens: 200
+    concurrency: [1, 4, 8, 16, 32, 64]
+    streaming: true
+    dataset: blazedit_10k
+    duration: 300
+    warmup: 30
+
+  long_context_scaling:
+    description: "Inputs from 1K to 16K tokens at production load. Stress-tests prefill performance."
+    input_tokens: 10000
+    output_tokens: 500
+    concurrency: [1, 4, 8, 16]
+    streaming: true
+    dataset: blazedit_10k
+    duration: 300
+    warmup: 30
+
+  production_traffic_mix:
+    description: "Balanced workload representing aggregate real traffic at varying concurrency."
+    input_tokens: 1000
+    output_tokens: 1000
+    concurrency: [1, 4, 8, 16, 32, 64]
+    streaming: true
+    dataset: blazedit_10k
+    duration: 300
+    warmup: 30
+
+  shared_system_prompt:
+    description: "Same prompt across 4-16 users served concurrently. Tests prefix caching / prompt reuse."
+    input_tokens: 3000
+    output_tokens: 500
+    concurrency: [4, 8, 16]
+    streaming: true
+    dataset: blazedit_10k
+    duration: 300
+    warmup: 30
+
+# ---------------------------------------------------------------------------
+# Model Deployments
+# ---------------------------------------------------------------------------
+# Each model defines a deployable unit shared across all three paths.
+#
+# Path-specific config:
+#   env:           SM_VLLM_* env vars (SMAI DLC only)
+#   hyperpod_args: vLLM CLI args (HyperPod EC2 image)
+#   hyperpod_env:  Pod env vars (HyperPod, non-SM_VLLM vars)
+#   byom:          Bedrock BYOM import config
+#
+# GPU configuration:
+#   ml.p6-b200.48xlarge = 8× NVIDIA B200 GPUs → tensor_parallel_size=8
+#   ml.p5e.48xlarge     = 8× NVIDIA H100      → tensor_parallel_size=8
+
+models:
+  # --- Example 1: Simple model (no special serving config) ---
+  gemma-4-31b-vllm:
+    model_name: google/gemma-4-31B-it
+    deployment_config: transformers-vllm
+    instance_type: ml.p6-b200.48xlarge
+    num_gpus: 8
+    variant: baseline
+    s3_model_uri: ""  # fill after: python download_models.py --region <REGION> --model=gemma-4-31b
+    byom:
+      base_model_id: "google.gemma-4-31b-it"
+      model_id: ""  # fill after import
+
+  # --- Example 2: Model with SMAI env + HyperPod args + BYOM ---
+  deepseek-v4-pro-vllm:
+    model_name: deepseek-ai/DeepSeek-V4-Pro
+    deployment_config: transformers-vllm
+    instance_type: ml.p6-b200.48xlarge
+    num_gpus: 8
+    variant: baseline
+    s3_model_uri: ""  # fill after: python download_models.py --region <REGION> --model=deepseek-v4-pro
+    # SMAI: env vars translated to vLLM args by the SageMaker DLC entrypoint
+    env:
+      SM_VLLM_KV_CACHE_DTYPE: "fp8"
+    # HyperPod: explicit CLI args (EC2 image doesn't have SM_VLLM_* translation)
+    hyperpod_args: ["--kv-cache-dtype", "fp8"]
+    # BYOM: Mantle import config
+    byom:
+      base_model_id: "deepseek.deepseek-v3.1"
+      model_id: ""  # fill after import
+
+  # --- Example 3: Complex model with speculative decoding ---
+  kimi-k2-6-nvfp4:
+    model_name: nvidia/Kimi-K2.6-NVFP4
+    deployment_config: transformers-vllm
+    instance_type: ml.p6-b200.48xlarge
+    num_gpus: 8
+    variant: optimized-nvfp4-eagle3
+    benchmark_tokenizer: Qwen/Qwen2.5-7B  # Proxy tokenizer for AIPerf (model's own requires trust_remote_code)
+    s3_model_uri: ""  # fill after download
+    # SMAI
+    env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+      SM_VLLM_TRUST_REMOTE_CODE: "true"
+      SM_VLLM_KV_CACHE_DTYPE: "fp8"
+      SM_VLLM_REASONING_PARSER: "kimi_k2"
+      SM_VLLM_CONFIG: "/opt/ml/model/vllm_config.yaml"
+      SM_VLLM_MM_ENCODER_TP_MODE: "data"
+      SM_VLLM_TOOL_CALL_PARSER: "kimi_k2"
+      SM_VLLM_ENABLE_AUTO_TOOL_CHOICE: ""
+    # HyperPod
+    hyperpod_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    hyperpod_args:
+      - "--speculative-config"
+      - '{"model": "lightseekorg/kimi-k2.6-eagle3-mla", "method": "eagle3", "num_speculative_tokens": 3}'
+      - "--kv-cache-dtype"
+      - "fp8"
+      - "--reasoning-parser"
+      - "kimi_k2"
+      - "--tool-call-parser"
+      - "kimi_k2"
+      - "--enable-auto-tool-choice"
+      - "--mm-encoder-tp-mode"
+      - "data"
+
+# ---------------------------------------------------------------------------
+# SageMaker Managed Inference Defaults
+# ---------------------------------------------------------------------------
+sagemaker_defaults:
+  region: <REGION>
+  deployment_target: managed-inference
+  cleanup: true  # cleanup between models (single instance via FTP)
+  sagemaker_image: 763104351884.dkr.ecr.{region}.amazonaws.com/vllm:0.20.2-gpu-py312-cu130-ubuntu22.04-sagemaker-v1.2
+  inference_ami_version: al2023-ami-sagemaker-inference-gpu-4-1
+  role_arn: arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>
+  ml_reservation_arn: arn:aws:sagemaker:<REGION>:<ACCOUNT_ID>:training-plan/<TRAINING_PLAN_NAME>
+  s3_output: s3://sagemaker-benchmark-{region}-<ACCOUNT_ID>/managed-inference
+  vllm_config:
+    max_model_len: "16384"
+    gpu_memory_utilization: "0.9"
+
+sagemaker_benchmarks:
+  - model: gemma-4-31b-vllm
+    workloads: [multi_turn_chat, rag_document_qa, agent_tool_calling, long_context_scaling, production_traffic_mix, shared_system_prompt]
+
+  - model: deepseek-v4-pro-vllm
+    workloads: [multi_turn_chat, rag_document_qa, agent_tool_calling, long_context_scaling, production_traffic_mix, shared_system_prompt]
+
+# ---------------------------------------------------------------------------
+# HyperPod EKS Defaults
+# ---------------------------------------------------------------------------
+hyperpod_defaults:
+  region: <REGION>
+  namespace: benchmarking
+  role_arn: arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>
+  s3_output: s3://sagemaker-benchmark-{region}-<ACCOUNT_ID>/hyperpod
+  hyperpod_cluster_name: "<CLUSTER_NAME>"
+  # EC2 vLLM image (NOT the SageMaker DLC — EC2 image respects CLI args)
+  vllm_image: public.ecr.aws/deep-learning-containers/vllm:0.20.2-gpu-py312-ec2
+  vllm_config:
+    max_model_len: "16384"
+    gpu_memory_utilization: "0.9"
+  cleanup: true
+  # VPC config for benchmark runner (AI Benchmark Job) to reach internal NLB
+  vpc_config:
+    SecurityGroupIds: [<HYPERPOD_SG>, <EKS_NODE_SG>]
+    Subnets: [<SUBNET_1>, <SUBNET_2>, <SUBNET_3>]
+
+hyperpod_benchmarks:
+  - model: gemma-4-31b-vllm
+    workloads: [multi_turn_chat, rag_document_qa, agent_tool_calling, long_context_scaling, production_traffic_mix, shared_system_prompt]
+
+  - model: deepseek-v4-pro-vllm
+    workloads: [multi_turn_chat, rag_document_qa, agent_tool_calling, long_context_scaling, production_traffic_mix, shared_system_prompt]
+
+# ---------------------------------------------------------------------------
+# Bedrock BYOM Defaults
+# ---------------------------------------------------------------------------
+byom_defaults:
+  region: <REGION>
+  role_arn: arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>
+  s3_output: s3://sagemaker-benchmark-{region}-<ACCOUNT_ID>/byom
+  mantle_endpoint: https://bedrock.<REGION>.amazonaws.com
+  ru_count: 1
+  processing_instance_type: ml.m7i.4xlarge
+  processing_volume_gb: 500
+
+# BYOM benchmarks reference the same models section (byom: sub-key)
+byom_benchmarks:
+  - model: gemma-4-31b-vllm
+    workloads: [multi_turn_chat, rag_document_qa, agent_tool_calling]
+
+  - model: deepseek-v4-pro-vllm
+    workloads: [multi_turn_chat, rag_document_qa, agent_tool_calling]

--- a/07-benchmark/autobench/infra/hyperpod-cluster-bootstrap.yaml
+++ b/07-benchmark/autobench/infra/hyperpod-cluster-bootstrap.yaml
@@ -1,0 +1,638 @@
+# ============================================================================
+# SageMaker HyperPod EKS Cluster Bootstrap
+# ============================================================================
+#
+# Deploys a fully-configured HyperPod cluster with networking ready for GPU
+# benchmarking workloads. Creates VPC, subnets (NLB-tagged), security groups
+# (port 80 + NodePort range), IAM roles, and the cluster itself.
+#
+# DEPLOYMENT:
+#   aws cloudformation deploy \
+#     --template-file hyperpod-cluster-bootstrap.yaml \
+#     --stack-name sagemaker-benchmark-hyperpod \
+#     --capabilities CAPABILITY_NAMED_IAM \
+#     --region us-east-2
+#
+# POST-DEPLOYMENT:
+#
+#   1. Get the EKS cluster name (auto-created by HyperPod):
+#      aws sagemaker describe-cluster --cluster-name <ClusterName> --region us-east-2 \
+#        --query 'Orchestrator.Eks.ClusterArn' --output text
+#
+#   2. Configure kubectl:
+#      EKS_NAME=$(aws sagemaker describe-cluster --cluster-name <ClusterName> \
+#        --query 'Orchestrator.Eks.ClusterArn' --output text | awk -F/ '{print $NF}')
+#      aws eks update-kubeconfig --name $EKS_NAME --region us-east-2
+#
+#   3. Install AWS Load Balancer Controller:
+#      # Add the EKS Helm repo
+#      helm repo add eks https://aws.github.io/eks-charts
+#      helm repo update
+#
+#      # Install the controller (use the LBControllerRoleArn from stack outputs)
+#      helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
+#        -n kube-system \
+#        --set clusterName=$EKS_NAME \
+#        --set serviceAccount.create=true \
+#        --set serviceAccount.name=aws-load-balancer-controller \
+#        --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=<LBControllerRoleArn> \
+#        --set region=us-east-2 \
+#        --set vpcId=<VpcId from outputs>
+#
+#   4. Add GPU node groups via Training Plan (FTP):
+#      GPU nodes are added by attaching an FTP-backed node group to the cluster.
+#      This is done via the SageMaker console or CLI, not CloudFormation.
+#      The node group will use the NodeSecurityGroup and private subnets from this stack.
+#
+#   5. Update benchmarks.yaml with the stack outputs:
+#      hyperpod_defaults:
+#        hyperpod_cluster_name: "<ClusterName>"
+#        vpc_config:
+#          SecurityGroupIds: [<NodeSecurityGroupId>, <BenchmarkSecurityGroupId>]
+#          Subnets: [<PrivateSubnet1>, <PrivateSubnet2>, <PrivateSubnet3>]
+#
+# ============================================================================
+
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  SageMaker HyperPod EKS cluster bootstrap for GPU benchmarking.
+  Creates VPC, subnets, security groups, IAM roles, and cluster.
+  Region-portable (uses AWS::Region). Default target: us-east-2.
+
+# ============================================================================
+# Parameters
+# ============================================================================
+Parameters:
+  ClusterName:
+    Type: String
+    Default: sagemaker-<CLUSTER_NAME>
+    Description: Name for the SageMaker HyperPod cluster
+
+  BenchmarkBucketName:
+    Type: String
+    Default: sagemaker-benchmark-us-east-2-<ACCOUNT_ID>
+    Description: S3 bucket for benchmark results and model weights
+
+  VpcCidr:
+    Type: String
+    Default: '10.0.0.0/16'
+    Description: CIDR block for the VPC
+
+  DefaultNodeInstanceType:
+    Type: String
+    Default: ml.t3.medium
+    Description: Instance type for the default (non-GPU) node group
+
+  DefaultNodeCount:
+    Type: Number
+    Default: 1
+    Description: Number of nodes in the default node group
+
+# ============================================================================
+# Resources
+# ============================================================================
+Resources:
+
+  # --------------------------------------------------------------------------
+  # VPC + Networking
+  # --------------------------------------------------------------------------
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Sub '${ClusterName}-vpc'
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub '${ClusterName}-igw'
+
+  AttachGateway:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
+  # Public subnets (for NAT Gateway)
+  PublicSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: '10.0.1.0/24'
+      AvailabilityZone: !Select [0, !GetAZs '']
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub '${ClusterName}-public-1'
+        - Key: kubernetes.io/role/elb
+          Value: '1'
+
+  PublicSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: '10.0.2.0/24'
+      AvailabilityZone: !Select [1, !GetAZs '']
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub '${ClusterName}-public-2'
+        - Key: kubernetes.io/role/elb
+          Value: '1'
+
+  PublicSubnet3:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: '10.0.3.0/24'
+      AvailabilityZone: !Select [2, !GetAZs '']
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub '${ClusterName}-public-3'
+        - Key: kubernetes.io/role/elb
+          Value: '1'
+
+  # Private subnets (for EKS nodes + internal NLB)
+  PrivateSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: '10.0.10.0/24'
+      AvailabilityZone: !Select [0, !GetAZs '']
+      Tags:
+        - Key: Name
+          Value: !Sub '${ClusterName}-private-1'
+        - Key: kubernetes.io/role/internal-elb
+          Value: '1'
+
+  PrivateSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: '10.0.11.0/24'
+      AvailabilityZone: !Select [1, !GetAZs '']
+      Tags:
+        - Key: Name
+          Value: !Sub '${ClusterName}-private-2'
+        - Key: kubernetes.io/role/internal-elb
+          Value: '1'
+
+  PrivateSubnet3:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: '10.0.12.0/24'
+      AvailabilityZone: !Select [2, !GetAZs '']
+      Tags:
+        - Key: Name
+          Value: !Sub '${ClusterName}-private-3'
+        - Key: kubernetes.io/role/internal-elb
+          Value: '1'
+
+  # NAT Gateway (single, in first public subnet)
+  NatGatewayEIP:
+    Type: AWS::EC2::EIP
+    DependsOn: AttachGateway
+    Properties:
+      Domain: vpc
+      Tags:
+        - Key: Name
+          Value: !Sub '${ClusterName}-nat-eip'
+
+  NatGateway:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt NatGatewayEIP.AllocationId
+      SubnetId: !Ref PublicSubnet1
+      Tags:
+        - Key: Name
+          Value: !Sub '${ClusterName}-nat'
+
+  # Route tables
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub '${ClusterName}-public-rt'
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: AttachGateway
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: '0.0.0.0/0'
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnet1RouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet1
+      RouteTableId: !Ref PublicRouteTable
+
+  PublicSubnet2RouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet2
+      RouteTableId: !Ref PublicRouteTable
+
+  PublicSubnet3RouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnet3
+      RouteTableId: !Ref PublicRouteTable
+
+  PrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub '${ClusterName}-private-rt'
+
+  PrivateRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      DestinationCidrBlock: '0.0.0.0/0'
+      NatGatewayId: !Ref NatGateway
+
+  PrivateSubnet1RouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnet1
+      RouteTableId: !Ref PrivateRouteTable
+
+  PrivateSubnet2RouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnet2
+      RouteTableId: !Ref PrivateRouteTable
+
+  PrivateSubnet3RouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnet3
+      RouteTableId: !Ref PrivateRouteTable
+
+  # --------------------------------------------------------------------------
+  # Security Groups
+  # --------------------------------------------------------------------------
+
+  # EKS Cluster Security Group (control plane)
+  ClusterSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: EKS cluster control plane security group
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub '${ClusterName}-cluster-sg'
+
+  # Node Security Group (HyperPod EKS nodes)
+  NodeSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for HyperPod EKS nodes
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub '${ClusterName}-node-sg'
+
+  # Node SG: Allow all traffic from self (node-to-node)
+  NodeSGIngressSelf:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref NodeSecurityGroup
+      IpProtocol: '-1'
+      SourceSecurityGroupId: !Ref NodeSecurityGroup
+      Description: Node-to-node communication
+
+  # Node SG: Allow port 80 from cluster SG (NLB health checks + traffic)
+  NodeSGIngressPort80:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref NodeSecurityGroup
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+      SourceSecurityGroupId: !Ref ClusterSecurityGroup
+      Description: NLB health checks and traffic from cluster SG
+
+  # Node SG: Allow NodePort range from VPC CIDR (NLB -> Pod routing)
+  NodeSGIngressNodePorts:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref NodeSecurityGroup
+      IpProtocol: tcp
+      FromPort: 30000
+      ToPort: 32767
+      CidrIp: '10.0.0.0/8'
+      Description: NodePort range for NLB to Pod routing
+
+  # Node SG: Allow traffic from cluster control plane
+  NodeSGIngressFromCluster:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref NodeSecurityGroup
+      IpProtocol: tcp
+      FromPort: 1025
+      ToPort: 65535
+      SourceSecurityGroupId: !Ref ClusterSecurityGroup
+      Description: Cluster control plane to nodes
+
+  # Node SG: Allow port 443 from cluster (for kubelet)
+  NodeSGIngressKubelet:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref NodeSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      SourceSecurityGroupId: !Ref ClusterSecurityGroup
+      Description: Cluster to node kubelet
+
+  # Cluster SG: Allow traffic from nodes
+  ClusterSGIngressFromNodes:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref ClusterSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      SourceSecurityGroupId: !Ref NodeSecurityGroup
+      Description: Nodes to cluster API server
+
+  # Benchmark Security Group (for Processing Jobs / AIPerf load generator)
+  BenchmarkSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for benchmark Processing Jobs (AIPerf)
+      VpcId: !Ref VPC
+      SecurityGroupEgress:
+        - IpProtocol: '-1'
+          CidrIp: '0.0.0.0/0'
+          Description: Allow all outbound (needs to reach NLB)
+      Tags:
+        - Key: Name
+          Value: !Sub '${ClusterName}-benchmark-sg'
+
+  # --------------------------------------------------------------------------
+  # IAM Roles
+  # --------------------------------------------------------------------------
+
+  # HyperPod Cluster Execution Role
+  HyperPodExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${ClusterName}-execution-role'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - sagemaker.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSageMakerClusterInstanceRolePolicy
+      Policies:
+        - PolicyName: HyperPodEKSPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - eks:*
+                  - ec2:Describe*
+                  - ec2:CreateNetworkInterface
+                  - ec2:DeleteNetworkInterface
+                  - ec2:CreateSecurityGroup
+                  - ec2:DeleteSecurityGroup
+                  - ec2:CreateTags
+                  - elasticloadbalancing:*
+                  - iam:CreateServiceLinkedRole
+                  - iam:PassRole
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:ListBucket
+                Resource:
+                  - !Sub 'arn:aws:s3:::${BenchmarkBucketName}'
+                  - !Sub 'arn:aws:s3:::${BenchmarkBucketName}/*'
+
+  # Node Instance Role (for EKS worker nodes)
+  NodeInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${ClusterName}-node-role'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+      Policies:
+        - PolicyName: BenchmarkS3Access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:ListBucket
+                Resource:
+                  - !Sub 'arn:aws:s3:::${BenchmarkBucketName}'
+                  - !Sub 'arn:aws:s3:::${BenchmarkBucketName}/*'
+
+  # AWS Load Balancer Controller IAM Policy
+  LBControllerPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub '${ClusterName}-lb-controller-policy'
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - iam:CreateServiceLinkedRole
+            Resource: '*'
+            Condition:
+              StringEquals:
+                iam:AWSServiceName: elasticloadbalancing.amazonaws.com
+          - Effect: Allow
+            Action:
+              - ec2:Describe*
+              - ec2:GetCoipPoolUsage
+              - ec2:DescribeCoipPools
+              - elasticloadbalancing:*
+              - cognito-idp:DescribeUserPoolClient
+              - acm:ListCertificates
+              - acm:DescribeCertificate
+              - iam:ListServerCertificates
+              - iam:GetServerCertificate
+              - waf-regional:*
+              - wafv2:*
+              - shield:*
+              - tag:GetResources
+              - tag:TagResources
+            Resource: '*'
+          - Effect: Allow
+            Action:
+              - ec2:AuthorizeSecurityGroupIngress
+              - ec2:RevokeSecurityGroupIngress
+              - ec2:CreateSecurityGroup
+              - ec2:DeleteSecurityGroup
+              - ec2:CreateTags
+              - ec2:DeleteTags
+            Resource: '*'
+
+  # Load Balancer Controller IRSA Role
+  # NOTE: The OIDC provider URL must be updated post-deployment once the EKS
+  # cluster is created. This role uses a placeholder condition.
+  LBControllerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${ClusterName}-lb-controller-role'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Sub 'arn:aws:iam::${AWS::AccountId}:oidc-provider/oidc.eks.${AWS::Region}.amazonaws.com'
+            Action: sts:AssumeRoleWithWebIdentity
+            # NOTE: Update the Condition below with the actual OIDC provider ID
+            # after the cluster is created. Get it with:
+            #   aws eks describe-cluster --name <EKS_NAME> \
+            #     --query "cluster.identity.oidc.issuer" --output text
+            Condition:
+              StringEquals:
+                'oidc.eks.${AWS::Region}.amazonaws.com:sub': 'system:serviceaccount:kube-system:aws-load-balancer-controller'
+      ManagedPolicyArns:
+        - !Ref LBControllerPolicy
+
+  # --------------------------------------------------------------------------
+  # SageMaker HyperPod Cluster
+  # --------------------------------------------------------------------------
+  HyperPodCluster:
+    Type: AWS::SageMaker::Cluster
+    DependsOn:
+      - PrivateSubnet1RouteTableAssoc
+      - PrivateSubnet2RouteTableAssoc
+      - PrivateSubnet3RouteTableAssoc
+      - NatGateway
+    Properties:
+      ClusterName: !Ref ClusterName
+      Orchestrator:
+        Eks:
+          ClusterArn: !Sub 'arn:aws:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}'
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref NodeSecurityGroup
+          - !Ref ClusterSecurityGroup
+        Subnets:
+          - !Ref PrivateSubnet1
+          - !Ref PrivateSubnet2
+          - !Ref PrivateSubnet3
+      InstanceGroups:
+        - InstanceGroupName: default-system
+          InstanceType: !Ref DefaultNodeInstanceType
+          InstanceCount: !Ref DefaultNodeCount
+          LifeCycleConfig:
+            SourceS3Uri: !Sub 's3://${BenchmarkBucketName}/hyperpod-lifecycle/'
+            OnCreate: on_create.sh
+          ExecutionRole: !GetAtt HyperPodExecutionRole.Arn
+      Tags:
+        - Key: project
+          Value: benchmarking-initiative
+        - Key: managed-by
+          Value: cloudformation
+
+# ============================================================================
+# Outputs
+# ============================================================================
+Outputs:
+  ClusterName:
+    Description: SageMaker HyperPod cluster name
+    Value: !Ref ClusterName
+    Export:
+      Name: !Sub '${AWS::StackName}-ClusterName'
+
+  VpcId:
+    Description: VPC ID (for benchmarks.yaml and Helm install)
+    Value: !Ref VPC
+    Export:
+      Name: !Sub '${AWS::StackName}-VpcId'
+
+  PrivateSubnetIds:
+    Description: Private subnet IDs (comma-separated, for benchmarks.yaml vpc_config.Subnets)
+    Value: !Join
+      - ','
+      - - !Ref PrivateSubnet1
+        - !Ref PrivateSubnet2
+        - !Ref PrivateSubnet3
+    Export:
+      Name: !Sub '${AWS::StackName}-PrivateSubnetIds'
+
+  NodeSecurityGroupId:
+    Description: Node security group ID (for benchmarks.yaml vpc_config.SecurityGroupIds)
+    Value: !Ref NodeSecurityGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-NodeSecurityGroupId'
+
+  BenchmarkSecurityGroupId:
+    Description: Benchmark SG ID (for benchmarks.yaml vpc_config.SecurityGroupIds)
+    Value: !Ref BenchmarkSecurityGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-BenchmarkSecurityGroupId'
+
+  ClusterSecurityGroupId:
+    Description: EKS cluster control plane security group
+    Value: !Ref ClusterSecurityGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-ClusterSecurityGroupId'
+
+  HyperPodExecutionRoleArn:
+    Description: HyperPod execution role ARN
+    Value: !GetAtt HyperPodExecutionRole.Arn
+
+  NodeInstanceRoleArn:
+    Description: Node instance role ARN
+    Value: !GetAtt NodeInstanceRole.Arn
+
+  LBControllerRoleArn:
+    Description: >-
+      IAM role ARN for AWS Load Balancer Controller (use in Helm install).
+      NOTE: Update the OIDC trust policy after cluster creation.
+    Value: !GetAtt LBControllerRole.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-LBControllerRoleArn'
+
+  KubectlCommand:
+    Description: Command to configure kubectl (replace EKS_NAME after cluster creation)
+    Value: !Sub >-
+      aws eks update-kubeconfig --name <EKS_NAME> --region ${AWS::Region}
+
+  BenchmarksYamlVpcConfig:
+    Description: Copy-paste this into benchmarks.yaml hyperpod_defaults.vpc_config
+    Value: !Sub |
+      vpc_config:
+        SecurityGroupIds: ["${NodeSecurityGroup}", "${BenchmarkSecurityGroup}"]
+        Subnets: ["${PrivateSubnet1}", "${PrivateSubnet2}", "${PrivateSubnet3}"]

--- a/07-benchmark/autobench/sdk/athena_ddl.sql
+++ b/07-benchmark/autobench/sdk/athena_ddl.sql
@@ -1,0 +1,74 @@
+-- Benchmarking Initiative: Athena Table DDL
+-- Run each statement separately in Athena console (us-east-2)
+-- Last updated: May 26, 2026
+
+-- Step 1: Create database
+CREATE DATABASE IF NOT EXISTS benchmarking;
+
+-- Step 2: Drop existing table
+DROP TABLE IF EXISTS benchmarking.benchmark_metrics;
+
+-- Step 3: Create table with expanded schema
+CREATE EXTERNAL TABLE benchmarking.benchmark_metrics (
+  job_id STRING,
+  model_key STRING,
+  model_name STRING,
+  model_id STRING,
+  concurrency INT,
+  input_tokens INT,
+  output_tokens INT,
+  streaming BOOLEAN,
+  duration INT,
+  warmup INT,
+  dataset STRING,
+  instance_type STRING,
+  num_gpus INT,
+  source_region STRING,
+  s3_output STRING,
+  `timestamp` STRING,
+  vllm_config STRING,
+  request_throughput_rps DOUBLE,
+  total_token_throughput_tps DOUBLE,
+  output_token_throughput_tps DOUBLE,
+  request_count DOUBLE,
+  ttft_avg_ms DOUBLE,
+  ttft_p50_ms DOUBLE,
+  ttft_p90_ms DOUBLE,
+  ttft_p99_ms DOUBLE,
+  itl_avg_ms DOUBLE,
+  itl_p50_ms DOUBLE,
+  itl_p90_ms DOUBLE,
+  itl_p99_ms DOUBLE,
+  e2e_latency_avg_ms DOUBLE,
+  e2e_latency_p50_ms DOUBLE,
+  e2e_latency_p90_ms DOUBLE,
+  e2e_latency_p99_ms DOUBLE,
+  prefill_tps_avg DOUBLE,
+  prefill_tps_p50 DOUBLE,
+  e2e_output_token_tps_avg DOUBLE,
+  e2e_output_token_tps_p50 DOUBLE,
+  e2e_output_token_tps_p90 DOUBLE,
+  ttst_p50_ms DOUBLE,
+  ttst_p90_ms DOUBLE,
+  output_sequence_length_avg DOUBLE,
+  input_sequence_length_avg DOUBLE,
+  error_request_count DOUBLE,
+  osl_mismatch_count DOUBLE,
+  benchmark_duration_sec DOUBLE,
+  error_rate DOUBLE,
+  vllm_version STRING,
+  kv_cache_dtype STRING,
+  quantization STRING,
+  benchmark_tokenizer STRING,
+  serving_config STRING,
+  aiperf_version STRING,
+  raw_aiperf_json STRING
+)
+PARTITIONED BY (environment STRING, model STRING, workload STRING)
+ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
+WITH SERDEPROPERTIES ('ignore.malformed.json' = 'true')
+LOCATION 's3://sagemaker-benchmark-<REGION>-<ACCOUNT_ID>/athena/results/'
+TBLPROPERTIES ('has_encrypted_data'='false');
+
+-- Step 4: Discover partitions
+MSCK REPAIR TABLE benchmarking.benchmark_metrics;

--- a/07-benchmark/autobench/sdk/athena_writer.py
+++ b/07-benchmark/autobench/sdk/athena_writer.py
@@ -1,0 +1,396 @@
+"""Shared utility: write flattened benchmark result with metrics to central Athena prefix.
+
+v2 — Enriched with self-describing serving context for tranche-independent comparisons.
+Each result row now includes top-level scalars for common QuickSight filter axes
+and a serving_config JSON blob for full audit trail.
+"""
+import hashlib
+import io
+import json
+import os
+import re
+import tarfile
+import boto3
+import yaml
+
+# Load athena config from benchmarks.yaml if available
+_athena_config = {}
+for cfg_path in ["../benchmarks.yaml", "/opt/ml/processing/input/script/benchmarks.yaml"]:
+    if os.path.exists(cfg_path):
+        with open(cfg_path) as f:
+            _athena_config = yaml.safe_load(f).get("athena", {})
+        break
+
+CENTRAL_BUCKET = _athena_config.get("bucket") or os.environ.get("ATHENA_BUCKET", "")
+CENTRAL_REGION = _athena_config.get("region") or os.environ.get("ATHENA_REGION", "us-east-2")
+ATHENA_PREFIX = _athena_config.get("prefix", "athena/results")
+
+
+def _get_bucket():
+    if not CENTRAL_BUCKET:
+        raise ValueError("No Athena bucket configured. Set 'athena.bucket' in benchmarks.yaml or ATHENA_BUCKET env var.")
+    return CENTRAL_BUCKET
+
+
+# ─── Serving Context Enrichment ─────────────────────────────────────────────
+
+
+def _parse_vllm_version(image_uri):
+    """Extract vLLM version from DLC image URI.
+
+    Example input:  "763104351884.dkr.ecr.us-east-2.amazonaws.com/vllm:0.20.2-gpu-py312-cu130-ubuntu22.04-sagemaker-v1.2"
+    Example output: "0.20.2"
+
+    Returns None if the version cannot be parsed.
+    """
+    if not image_uri:
+        return None
+    # Match pattern: /vllm:<version>-  (version is digits + dots)
+    m = re.search(r"/vllm:(\d+\.\d+(?:\.\d+)?)", image_uri)
+    return m.group(1) if m else None
+
+
+def _safe_float(value):
+    """Safely convert a value to float, returning None on failure."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def enrich_with_serving_context(record, model_config=None, defaults_config=None, config_source=None):
+    """Enrich a benchmark record with self-describing serving context fields.
+
+    Adds top-level scalar columns for common QuickSight filter axes and a
+    serving_config JSON blob for full audit trail.
+
+    Args:
+        record: The benchmark result dict (modified in-place).
+        model_config: The model's config dict from benchmarks.yaml (e.g. models.gemma-4-31b-vllm).
+                      If None, enrichment is skipped (backward-compatible).
+        defaults_config: The defaults dict (sagemaker_defaults, hyperpod_defaults, or byom_defaults).
+                         If None, enrichment is skipped (backward-compatible).
+        config_source: Optional filename of the config that produced this record
+                       (e.g. "benchmarks.yaml", "benchmarks-hyperpod.yaml"). For audit trail.
+
+    Returns:
+        The record dict (same object, modified in-place).
+    """
+    if not model_config and not defaults_config:
+        return record
+
+    model_config = model_config or {}
+    defaults_config = defaults_config or {}
+    env = model_config.get("env", {})
+    vllm_config = defaults_config.get("vllm_config", {})
+
+    # ─── Top-Level Scalars (QuickSight-native filtering) ────────────────────
+
+    # vllm_version: parsed from the DLC image tag
+    image_uri = defaults_config.get("sagemaker_image", "")
+    # For HyperPod, the image might be in a different field
+    if not image_uri:
+        image_uri = defaults_config.get("vllm_image", "")
+    record["vllm_version"] = _parse_vllm_version(image_uri)
+
+    # kv_cache_dtype: from model env var, default "auto"
+    record["kv_cache_dtype"] = env.get("SM_VLLM_KV_CACHE_DTYPE", "auto")
+
+    # quantization: from model env var, default "none"
+    record["quantization"] = env.get("SM_VLLM_QUANTIZATION", "none")
+
+    # benchmark_tokenizer: proxy tokenizer if used (null = model's own)
+    record["benchmark_tokenizer"] = model_config.get("benchmark_tokenizer", None)
+
+    # ─── JSON Blob (full audit trail) ───────────────────────────────────────
+
+    serving_config = {
+        "max_model_len": vllm_config.get("max_model_len"),
+        "gpu_memory_utilization": vllm_config.get("gpu_memory_utilization"),
+        "instance_type": record.get("instance_type"),
+        "moe_backend": env.get("SM_VLLM_MOE_BACKEND"),
+        "speculative_config": env.get("SM_VLLM_SPECULATIVE_MODEL"),
+        "dlc_image": image_uri if image_uri else None,
+        "env": env if env else None,
+        "inference_ami_version": defaults_config.get("inference_ami_version"),
+        "training_plan_arn": defaults_config.get("ml_reservation_arn"),
+        "model_name": model_config.get("model_name"),
+        "num_gpus": model_config.get("num_gpus"),
+        "s3_model_uri": model_config.get("s3_model_uri"),
+        "config_source": config_source,
+    }
+
+    # Compute config_hash: deterministic fingerprint of everything that affects
+    # benchmark results. If ANY performance-impacting parameter changes, the hash
+    # changes. Non-performance fields (config_source, training_plan_arn) are excluded.
+    #
+    # Rule: if it can change the numbers, it's in the hash.
+    #       if it can't (billing, filenames), it's excluded.
+    _NON_PERF_FIELDS = {"config_source", "training_plan_arn", "config_hash"}
+    hash_input = json.dumps(
+        {k: v for k, v in sorted(serving_config.items()) if k not in _NON_PERF_FIELDS},
+        sort_keys=True
+    )
+    serving_config["config_hash"] = hashlib.sha256(hash_input.encode()).hexdigest()[:16]
+
+    # Remove None values to keep the blob compact
+    serving_config = {k: v for k, v in serving_config.items() if v is not None}
+    record["serving_config"] = json.dumps(serving_config, sort_keys=True)
+
+    return record
+
+
+def _compute_error_rate(aiperf):
+    """Compute error rate from AIPerf metrics JSON.
+
+    Uses osl_mismatch_count and request_count if available.
+    Returns float (0.0 to 1.0) or None if not computable.
+    """
+    if not aiperf:
+        return None
+
+    request_count = aiperf.get("request_count", {}).get("avg")
+    osl_mismatch = aiperf.get("osl_mismatch_count", {}).get("avg")
+
+    if request_count and request_count > 0 and osl_mismatch is not None:
+        return round(osl_mismatch / request_count, 6)
+
+    # Fallback: check for error_count field
+    error_count = aiperf.get("error_count", {}).get("avg")
+    if request_count and request_count > 0 and error_count is not None:
+        return round(error_count / request_count, 6)
+
+    return None
+
+
+def _compute_job_id(record):
+    """Compute a deterministic job_id that uniquely identifies a benchmark run.
+
+    Same model + workload + concurrency + config = same job_id = same S3 key.
+    Re-runs overwrite the previous record. No duplicates.
+    """
+    unique_factors = json.dumps({
+        "concurrency": record.get("concurrency"),
+        "input_tokens": record.get("input_tokens"),
+        "output_tokens": record.get("output_tokens"),
+        "dataset": record.get("dataset"),
+        "serving_config": record.get("serving_config", ""),
+    }, sort_keys=True)
+    run_hash = hashlib.sha256(unique_factors.encode()).hexdigest()[:8]
+
+    model_key = record.get("model_key", "unknown")
+    workload = record.get("workload", "unknown")
+    concurrency = record.get("concurrency", 0)
+
+    return f"{model_key}--{workload}--c{concurrency}--{run_hash}"
+
+
+# ─── Metrics Extraction ─────────────────────────────────────────────────────
+
+
+def extract_metrics_from_s3(s3_output, source_region):
+    """Download the results tarball from S3 and extract key metrics."""
+    s3 = boto3.client("s3", region_name=source_region)
+    # Find the tarball in the output location
+    bucket = s3_output.replace("s3://", "").split("/")[0]
+    prefix = "/".join(s3_output.replace("s3://", "").split("/")[1:]).rstrip("/") + "/"
+
+    try:
+        resp = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)
+        tar_key = None
+        for obj in resp.get("Contents", []):
+            if obj["Key"].endswith(".tar.gz"):
+                tar_key = obj["Key"]
+                break
+        if not tar_key:
+            return {}
+
+        # Download and extract
+        tar_obj = s3.get_object(Bucket=bucket, Key=tar_key)
+        tar_bytes = io.BytesIO(tar_obj["Body"].read())
+        with tarfile.open(fileobj=tar_bytes, mode="r:gz") as tf:
+            for member in tf.getmembers():
+                if member.name.endswith("profile_export_aiperf.json"):
+                    f = tf.extractfile(member)
+                    if f:
+                        return json.loads(f.read().decode())
+    except Exception:
+        pass
+    return {}
+
+
+def flatten_metrics(aiperf):
+    """Extract the key metrics into a flat dict for Athena."""
+    if not aiperf:
+        return {}
+    m = {}
+
+    # Throughput
+    m["request_throughput_rps"] = aiperf.get("request_throughput", {}).get("avg")
+    m["total_token_throughput_tps"] = aiperf.get("total_token_throughput", {}).get("avg")
+    m["output_token_throughput_tps"] = aiperf.get("output_token_throughput", {}).get("avg")
+    m["request_count"] = aiperf.get("request_count", {}).get("avg")
+
+    # TTFT
+    ttft = aiperf.get("time_to_first_token", {})
+    m["ttft_avg_ms"] = ttft.get("avg")
+    m["ttft_p50_ms"] = ttft.get("p50")
+    m["ttft_p90_ms"] = ttft.get("p90")
+    m["ttft_p99_ms"] = ttft.get("p99")
+
+    # ITL
+    itl = aiperf.get("inter_token_latency", {})
+    m["itl_avg_ms"] = itl.get("avg")
+    m["itl_p50_ms"] = itl.get("p50")
+    m["itl_p90_ms"] = itl.get("p90")
+    m["itl_p99_ms"] = itl.get("p99")
+
+    # E2E latency
+    e2e = aiperf.get("request_latency", {})
+    m["e2e_latency_avg_ms"] = e2e.get("avg")
+    m["e2e_latency_p50_ms"] = e2e.get("p50")
+    m["e2e_latency_p90_ms"] = e2e.get("p90")
+    m["e2e_latency_p99_ms"] = e2e.get("p99")
+
+    # Prefill throughput
+    prefill = aiperf.get("prefill_throughput_per_user", {})
+    m["prefill_tps_avg"] = prefill.get("avg")
+    m["prefill_tps_p50"] = prefill.get("p50")
+
+    # E2E output token throughput (user-perceived, includes TTFT)
+    e2e_otp = aiperf.get("e2e_output_token_throughput", {})
+    m["e2e_output_token_tps_avg"] = e2e_otp.get("avg")
+    m["e2e_output_token_tps_p50"] = e2e_otp.get("p50")
+    m["e2e_output_token_tps_p90"] = e2e_otp.get("p90")
+
+    # Time to second token (decode startup)
+    ttst = aiperf.get("time_to_second_token", {})
+    m["ttst_p50_ms"] = ttst.get("p50")
+    m["ttst_p90_ms"] = ttst.get("p90")
+
+    # Sequence lengths (actual vs requested)
+    m["output_sequence_length_avg"] = aiperf.get("output_sequence_length", {}).get("avg")
+    m["input_sequence_length_avg"] = aiperf.get("input_sequence_length", {}).get("avg")
+
+    # Error/quality metrics
+    m["error_request_count"] = aiperf.get("error_request_count", {}).get("avg")
+    m["osl_mismatch_count"] = aiperf.get("osl_mismatch_count", {}).get("avg")
+    m["benchmark_duration_sec"] = aiperf.get("benchmark_duration", {}).get("avg")
+
+    # Metadata
+    m["aiperf_version"] = aiperf.get("aiperf_version")
+
+    # Dataset — extracted from input_config
+    input_config = aiperf.get("input_config", {})
+    aiperf_dataset = input_config.get("input", {}).get("public_dataset")
+    if aiperf_dataset:
+        m["dataset"] = aiperf_dataset  # AIPerf's actual dataset takes precedence (runtime truth)
+
+    # Raw JSON blob — full AIPerf output for ad-hoc Athena queries
+    # Exclude large objects (input_config contains resolved prompts metadata,
+    # telemetry_data and error_summary are useful to keep)
+    raw_blob = {k: v for k, v in aiperf.items() if k != "input_config"}
+    m["raw_aiperf_json"] = json.dumps(raw_blob)
+
+    return m
+
+
+# ─── Write to Athena ────────────────────────────────────────────────────────
+
+
+def write_athena_record(record, model_config=None, defaults_config=None, config_source=None):
+    """Write a flattened benchmark record with metrics to the central Athena prefix.
+
+    Args:
+        record: Dict with benchmark metadata (job_id, environment, model_key, etc.).
+        model_config: Optional model config dict from benchmarks.yaml for serving context enrichment.
+        defaults_config: Optional defaults dict (sagemaker_defaults, etc.) for serving context enrichment.
+
+    If model_config/defaults_config are not provided, the record is written without
+    serving context enrichment (backward-compatible with existing call sites).
+    """
+    s3 = boto3.client("s3", region_name=CENTRAL_REGION)
+
+    # Extract metrics from the results tarball
+    s3_output = record.get("s3_output", "")
+    source_region = record.get("source_region", CENTRAL_REGION)
+    aiperf = {}
+    if s3_output:
+        aiperf = extract_metrics_from_s3(s3_output, source_region)
+        record.update(flatten_metrics(aiperf))
+
+    # Enrich with serving context (if config provided)
+    enrich_with_serving_context(record, model_config, defaults_config, config_source=config_source)
+
+    # Compute error rate from AIPerf data
+    error_rate = _compute_error_rate(aiperf)
+    if error_rate is not None:
+        record["error_rate"] = error_rate
+
+    # Compute deterministic job_id (overwrites any caller-provided job_id)
+    record["job_id"] = _compute_job_id(record)
+
+    # Strip carrier keys that shouldn't be persisted
+    record.pop("model_config", None)
+    record.pop("defaults_config", None)
+
+    # Partition key: environment/model/workload
+    env = record.get("environment", "unknown")
+    model = record.get("model_key", "unknown")
+    workload = record.get("workload", "unknown")
+    key = f"{ATHENA_PREFIX}/environment={env}/model={model}/workload={workload}/{record['job_id']}.json"
+
+    try:
+        s3.put_object(
+            Bucket=_get_bucket(),
+            Key=key,
+            Body=json.dumps(record) + "\n",
+            ContentType="application/json",
+        )
+    except Exception:
+        pass  # non-fatal — don't break the benchmark run
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Extract metrics from benchmark results and write to Athena.")
+    parser.add_argument("s3_output", help="S3 location of benchmark results (e.g. s3://bucket/path/)")
+    parser.add_argument("--environment", default="managed-inference")
+    parser.add_argument("--model", required=True, help="Model key")
+    parser.add_argument("--workload", required=True, help="Workload key")
+    parser.add_argument("--concurrency", type=int, required=True)
+    parser.add_argument("--region", default=CENTRAL_REGION, help="Source region of the results")
+    parser.add_argument("--config", default="../benchmarks.yaml", help="Path to benchmarks.yaml for serving context")
+    args = parser.parse_args()
+
+    # Load config for enrichment
+    model_config = None
+    defaults_config = None
+    if os.path.exists(args.config):
+        with open(args.config) as f:
+            cfg = yaml.safe_load(f)
+        model_config = cfg.get("models", {}).get(args.model)
+        env_defaults_key = {"managed-inference": "sagemaker_defaults", "hyperpod": "hyperpod_defaults", "byom": "byom_defaults"}
+        defaults_config = cfg.get(env_defaults_key.get(args.environment, "sagemaker_defaults"), {})
+
+    record = {
+        "job_id": f"{args.model}--{args.workload}--c{args.concurrency}",
+        "environment": args.environment,
+        "model_key": args.model,
+        "workload": args.workload,
+        "concurrency": args.concurrency,
+        "s3_output": args.s3_output,
+        "source_region": args.region,
+    }
+    write_athena_record(record, model_config=model_config, defaults_config=defaults_config)
+    aiperf = extract_metrics_from_s3(args.s3_output, args.region)
+    metrics = flatten_metrics(aiperf)
+    if metrics:
+        print(f"✓ Written to s3://{_get_bucket()}/{ATHENA_PREFIX}/")
+        for k, v in metrics.items():
+            if v is not None:
+                print(f"  {k}: {v:.4f}" if isinstance(v, float) else f"  {k}: {v}")
+    else:
+        print("✗ No metrics found in tarball")

--- a/07-benchmark/autobench/sdk/backfill.py
+++ b/07-benchmark/autobench/sdk/backfill.py
@@ -63,6 +63,10 @@ def main():
     parser.add_argument("--region", default="us-east-2")
     parser.add_argument("--dry-run", action="store_true",
                         help="Print what would be written without writing")
+    parser.add_argument("--since", default=None,
+                        help="Only process tarballs with timestamp >= this value (format: 20260527 or 20260527T100000)")
+    parser.add_argument("--latest-only", action="store_true",
+                        help="For each (workload, concurrency) combo, only process the most recent tarball (skips older/failed runs)")
     args = parser.parse_args()
 
     # Load config
@@ -86,9 +90,9 @@ def main():
         print(f"\n{'─'*60}")
         print(f"[backfill] {model_key}")
         print(f"{'─'*60}")
-        _backfill_model(model_key, args.environment, args.region, args.dry_run, args.config, local_config)
+        _backfill_model(model_key, args.environment, args.region, args.dry_run, args.config, local_config, since=args.since, latest_only=args.latest_only)
 
-def _backfill_model(model_key, environment, region, dry_run, config_path, local_config):
+def _backfill_model(model_key, environment, region, dry_run, config_path, local_config, since=None, latest_only=False):
     """Backfill a single model's results."""
     models_key = "byom_models" if environment == "byom" else "models"
     model_cfg = local_config.get(models_key, {}).get(model_key)
@@ -125,6 +129,39 @@ def _backfill_model(model_key, environment, region, dry_run, config_path, local_
         return
 
     print(f"Found {len(tarballs)} tarballs for {model_key}")
+
+    # --since filter: drop tarballs older than the specified timestamp
+    if since:
+        filtered = []
+        for key in tarballs:
+            parts = key.split("/")
+            try:
+                model_idx = parts.index(model_key)
+                ts = parts[model_idx + 3] if len(parts) > model_idx + 3 else ""
+            except (ValueError, IndexError):
+                ts = ""
+            if ts >= since:
+                filtered.append(key)
+        print(f"  --since {since}: {len(tarballs)} → {len(filtered)} tarballs")
+        tarballs = filtered
+
+    # --latest-only filter: for each (workload, concurrency) combo, keep only the newest tarball
+    if latest_only:
+        from collections import defaultdict
+        groups = defaultdict(list)
+        for key in tarballs:
+            parts = key.split("/")
+            try:
+                model_idx = parts.index(model_key)
+                wl = parts[model_idx + 1]
+                conc_part = parts[model_idx + 2]
+                ts = parts[model_idx + 3] if len(parts) > model_idx + 3 else ""
+                groups[(wl, conc_part)].append((ts, key))
+            except (ValueError, IndexError):
+                groups[("unknown", "unknown")].append(("", key))
+        # Keep only the latest (max timestamp) per group
+        tarballs = [max(entries, key=lambda x: x[0])[1] for entries in groups.values()]
+        print(f"  --latest-only: keeping {len(tarballs)} latest tarballs (1 per workload×concurrency)")
 
     # Track config loading (cache across jobs with same config)
     s3_config_cache = {}

--- a/07-benchmark/autobench/sdk/backfill.py
+++ b/07-benchmark/autobench/sdk/backfill.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Backfill Athena records from existing S3 tarballs with enriched serving context.
+
+v2 — Loads the benchmarks.yaml used for each run (from processing-configs/ in S3)
+to populate serving context fields (vllm_version, quantization, kv_cache_dtype, etc.).
+
+Falls back to local benchmarks.yaml if the run-specific config isn't available in S3
+(e.g., for locally-executed runs that didn't use --submit).
+"""
+import argparse
+import io
+import re
+import boto3
+import yaml
+from athena_writer import write_athena_record
+
+
+def _load_config_from_s3(s3_client, bucket, job_name):
+    """Try to load benchmarks.yaml from processing-configs/{job_name}/ in S3.
+
+    Returns parsed config dict, or None if not found.
+    """
+    key = f"processing-configs/{job_name}/benchmarks.yaml"
+    try:
+        resp = s3_client.get_object(Bucket=bucket, Key=key)
+        content = resp["Body"].read().decode("utf-8")
+        return yaml.safe_load(content)
+    except s3_client.exceptions.NoSuchKey:
+        return None
+    except Exception:
+        return None
+
+
+def _infer_job_name_from_path(model_key, workload, concurrency, timestamp):
+    """Infer the Processing Job name from the S3 path components.
+
+    Processing jobs are typically named like: bench-{model_key}-{workload}-c{N}
+    or: bmk-prod-{model_key}-{workload}-c{N}-{timestamp}
+
+    This is a best-effort heuristic — if it doesn't match, we'll fall back to local config.
+    """
+    # Common patterns used by benchmark.py --submit
+    candidates = [
+        f"bench-{model_key}-{workload}-c{concurrency}",
+        f"bmk-prod-{model_key}-{workload}-c{concurrency}",
+        f"bmk-{model_key}-{workload}-c{concurrency}",
+    ]
+    return candidates
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Backfill Athena metrics from S3 tarballs with enriched serving context."
+    )
+    parser.add_argument("--model", help="Model key (e.g. gemma-4-31b-vllm). If omitted, backfills all models in config.")
+    parser.add_argument(
+        "--environment", required=True,
+        choices=["managed-inference", "hyperpod", "byom"],
+        help="Benchmark environment"
+    )
+    parser.add_argument("--config", default="../benchmarks.yaml",
+                        help="Path to benchmarks.yaml")
+    parser.add_argument("--region", default="us-east-2")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print what would be written without writing")
+    args = parser.parse_args()
+
+    # Load config
+    with open(args.config) as f:
+        local_config = yaml.safe_load(f)
+
+    # Determine which models to backfill
+    if args.model:
+        model_keys = [args.model]
+    else:
+        benchmarks_key = {
+            "managed-inference": "sagemaker_benchmarks",
+            "hyperpod": "hyperpod_benchmarks",
+            "byom": "byom_benchmarks",
+        }[args.environment]
+        entries = local_config.get(benchmarks_key, [])
+        model_keys = list(dict.fromkeys(e["model"] for e in entries))
+        print(f"Backfilling {len(model_keys)} models from {benchmarks_key}\n")
+
+    for model_key in model_keys:
+        print(f"\n{'─'*60}")
+        print(f"[backfill] {model_key}")
+        print(f"{'─'*60}")
+        _backfill_model(model_key, args.environment, args.region, args.dry_run, args.config, local_config)
+
+def _backfill_model(model_key, environment, region, dry_run, config_path, local_config):
+    """Backfill a single model's results."""
+    models_key = "byom_models" if environment == "byom" else "models"
+    model_cfg = local_config.get(models_key, {}).get(model_key)
+    if not model_cfg:
+        print(f"  ⚠️  Model '{model_key}' not in config, skipping")
+        return
+
+    defaults_key = {
+        "managed-inference": "sagemaker_defaults",
+        "hyperpod": "hyperpod_defaults",
+        "byom": "byom_defaults"
+    }[environment]
+    local_defaults = local_config.get(defaults_key, {})
+    s3_output_template = local_defaults.get("s3_output", "").format(region=region)
+    bucket = s3_output_template.replace("s3://", "").split("/")[0]
+    prefix_base = "/".join(s3_output_template.replace("s3://", "").split("/")[1:])
+    prefix = f"{prefix_base}/{model_key}/"
+
+    # Get workload configs for token counts
+    workloads = local_config.get("workloads", {})
+
+    s3 = boto3.client("s3", region_name=region)
+
+    # List all tarballs for this model
+    paginator = s3.get_paginator("list_objects_v2")
+    tarballs = []
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            if obj["Key"].endswith(".tar.gz") and obj["Size"] >= 1000:
+                tarballs.append(obj["Key"])
+
+    if not tarballs:
+        print(f"No tarballs found under s3://{bucket}/{prefix}")
+        return
+
+    print(f"Found {len(tarballs)} tarballs for {model_key}")
+
+    # Track config loading (cache across jobs with same config)
+    s3_config_cache = {}
+    count = 0
+    skipped = 0
+
+    for key in tarballs:
+        parts = key.split("/")
+
+        # Parse: {prefix_base}/{model}/{workload}/p6-b200-c{N}/{timestamp}/...
+        try:
+            model_idx = parts.index(model_key)
+        except ValueError:
+            skipped += 1
+            continue
+
+        workload = parts[model_idx + 1]
+        m = re.search(r"-c(\d+)", parts[model_idx + 2])
+        concurrency = int(m.group(1)) if m else 1
+        timestamp = parts[model_idx + 3] if len(parts) > model_idx + 3 else "unknown"
+
+        wl_cfg = workloads.get(workload, {})
+        s3_path = f"s3://{bucket}/{'/'.join(parts[:model_idx + 4])}/"
+
+        # Try to load run-specific config from S3
+        job_candidates = _infer_job_name_from_path(model_key, workload, concurrency, timestamp)
+        run_config = None
+        for candidate in job_candidates:
+            if candidate in s3_config_cache:
+                run_config = s3_config_cache[candidate]
+                break
+            loaded = _load_config_from_s3(s3, bucket, candidate)
+            s3_config_cache[candidate] = loaded
+            if loaded:
+                run_config = loaded
+                break
+
+        # Resolve model_config and defaults_config
+        if run_config:
+            effective_model_cfg = run_config.get("models", {}).get(model_key, model_cfg)
+            effective_defaults = run_config.get(defaults_key, local_defaults)
+            config_source = "s3"
+        else:
+            effective_model_cfg = model_cfg
+            effective_defaults = local_defaults
+            config_source = "local (fallback)"
+
+        record = {
+            "job_id": f"{model_key}--{workload}--c{concurrency}-{timestamp}",
+            "environment": environment,
+            "model_key": model_key,
+            "model_name": effective_model_cfg.get("model_name", model_cfg["model_name"]),
+            "workload": workload,
+            "concurrency": concurrency,
+            "input_tokens": wl_cfg.get("input_tokens", 1000),
+            "output_tokens": wl_cfg.get("output_tokens", 500),
+            "streaming": wl_cfg.get("streaming", True),
+            "duration": wl_cfg.get("duration", 300),
+            "warmup": wl_cfg.get("warmup", 30),
+            "dataset": wl_cfg.get("dataset"),
+            "instance_type": effective_model_cfg.get("instance_type", model_cfg.get("instance_type", "")),
+            "num_gpus": effective_model_cfg.get("num_gpus", model_cfg.get("num_gpus", 8)),
+            "source_region": region,
+            "s3_output": s3_path,
+            "timestamp": timestamp,
+        }
+
+        if dry_run:
+            from athena_writer import enrich_with_serving_context, _parse_vllm_version
+            enrich_with_serving_context(record, effective_model_cfg, effective_defaults)
+            vllm_v = record.get("vllm_version", "?")
+            print(f"  [DRY-RUN] {workload} c{concurrency} | vllm={vllm_v} | config={config_source}")
+        else:
+            write_athena_record(record, model_config=effective_model_cfg, defaults_config=effective_defaults)
+            count += 1
+            vllm_v = "?"  # Will be set by write_athena_record internally
+            print(f"  ✓ {workload} c{concurrency} ({timestamp}) [config: {config_source}]")
+
+    print(f"\n  Backfilled {count} records for {model_key} ({skipped} skipped)")
+    if dry_run:
+        print("  (Dry run — nothing was written)")
+
+
+if __name__ == "__main__":
+    main()

--- a/07-benchmark/autobench/sdk/benchmark.py
+++ b/07-benchmark/autobench/sdk/benchmark.py
@@ -1,0 +1,899 @@
+#!/usr/bin/env python3
+"""
+SDK-based benchmarking execution path.
+
+Deploys models and runs benchmark sweeps directly via boto3, bypassing
+ml-container-creator for faster iteration. Reads the same benchmarks.yaml
+as the Node.js orchestrator.
+
+Usage:
+    python sdk/benchmark.py --validate
+    python sdk/benchmark.py --model=gemma --workload=multi_turn
+    python sdk/benchmark.py --deploy-only --model=gemma
+    python sdk/benchmark.py --benchmark-only --model=gemma
+    python sdk/benchmark.py --cleanup --model=gemma
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+import boto3
+import yaml
+
+REGION = os.getenv("AWS_REGION", "us-west-2")
+RESULTS_DIR = Path("results")
+
+# --- Config Loading ---
+
+def load_config(path="benchmarks.yaml"):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def expand_jobs(config, model_filter=None, workload_filter=None):
+    """Expand benchmarks into individual jobs: (model × workload × concurrency)."""
+    jobs = []
+    for bench in config["sagemaker_benchmarks"]:
+        model_key = bench["model"]
+        model = config["models"].get(model_key)
+        if not model:
+            print(f"ERROR: Unknown model '{model_key}'", file=sys.stderr)
+            sys.exit(1)
+        if model_filter and model_filter not in model_key:
+            continue
+        for wl_name in bench["workloads"]:
+            if workload_filter and workload_filter not in wl_name:
+                continue
+            workload = config["workloads"].get(wl_name)
+            if not workload:
+                print(f"ERROR: Unknown workload '{wl_name}'", file=sys.stderr)
+                sys.exit(1)
+            for concurrency in workload["concurrency"]:
+                jobs.append({
+                    "id": f"{model_key}--{wl_name}--c{concurrency}",
+                    "model_key": model_key,
+                    "workload_key": wl_name,
+                    "model_name": model["model_name"],
+                    "benchmark_tokenizer": model.get("benchmark_tokenizer"),
+                    "instance_type": model["instance_type"],
+                    "num_gpus": model.get("num_gpus", 1),
+                    "base_image": model.get("base_image"),
+                    "variant": model.get("variant", "baseline"),
+                    "optimize_model": model.get("optimize_model", False),
+                    "concurrency": concurrency,
+                    "input_tokens": workload["input_tokens"],
+                    "output_tokens": workload["output_tokens"],
+                    "streaming": workload.get("streaming", True),
+                    "duration": workload.get("duration", 300),
+                    "warmup": workload.get("warmup", 30),
+                    "dataset": workload.get("dataset"),
+                })
+    return jobs
+
+
+# --- ECR Image Management ---
+
+def get_ecr_image(base_image):
+    """Ensure the vLLM image is in ECR. Uses CodeBuild to mirror if needed (no local Docker)."""
+    sts = boto3.client("sts", region_name="us-east-2")
+    account = sts.get_caller_identity()["Account"]
+    ecr_client = boto3.client("ecr", region_name=REGION)
+    repo_name = "benchmarking-initiative"
+    tag = base_image.split(":")[-1] if ":" in base_image else "latest"
+    ecr_uri = f"{account}.dkr.ecr.{REGION}.amazonaws.com/{repo_name}:{tag}"
+
+    # Check if image already exists in ECR
+    try:
+        ecr_client.describe_images(repositoryName=repo_name, imageIds=[{"imageTag": tag}])
+        print(f"  ✓ ECR image exists: {ecr_uri}")
+        return ecr_uri
+    except ecr_client.exceptions.ImageNotFoundException:
+        pass
+    except ecr_client.exceptions.RepositoryNotFoundException:
+        ecr_client.create_repository(repositoryName=repo_name)
+        print(f"  ✓ Created ECR repo: {repo_name}")
+
+    # Use CodeBuild to pull from Docker Hub and push to ECR (no local Docker needed)
+    print(f"  ⏳ Mirroring {base_image} → ECR via CodeBuild...")
+    cb_client = boto3.client("codebuild", region_name=REGION)
+    project_name = "bench-image-mirror"
+
+    # Ensure CodeBuild project exists
+    try:
+        cb_client.batch_get_projects(names=[project_name])["projects"][0]
+    except (IndexError, KeyError):
+        # Create a minimal CodeBuild project for image mirroring
+        iam = boto3.client("iam")
+        role_arn = _ensure_codebuild_role(iam, account)
+        cb_client.create_project(
+            name=project_name,
+            source={"type": "NO_SOURCE", "buildspec": "version: 0.2\nphases:\n  build:\n    commands:\n      - echo placeholder"},
+            artifacts={"type": "NO_ARTIFACTS"},
+            environment={
+                "type": "LINUX_CONTAINER",
+                "computeType": "BUILD_GENERAL1_MEDIUM",
+                "image": "aws/codebuild/standard:7.0",
+                "privilegedMode": True,
+            },
+            serviceRole=role_arn,
+        )
+        print(f"  ✓ Created CodeBuild project: {project_name}")
+
+    # Start build with inline buildspec that mirrors the image
+    buildspec = f"""version: 0.2
+phases:
+  pre_build:
+    commands:
+      - aws ecr get-login-password --region {REGION} | docker login --username AWS --password-stdin {account}.dkr.ecr.{REGION}.amazonaws.com
+  build:
+    commands:
+      - docker pull --platform linux/amd64 {base_image}
+      - docker tag {base_image} {ecr_uri}
+      - docker push {ecr_uri}
+"""
+    build = cb_client.start_build(
+        projectName=project_name,
+        buildspecOverride=buildspec,
+    )
+    build_id = build["build"]["id"]
+    print(f"  ⏳ CodeBuild started: {build_id}")
+
+    # Poll for completion
+    for _ in range(60):
+        resp = cb_client.batch_get_builds(ids=[build_id])
+        status = resp["builds"][0]["buildStatus"]
+        if status == "SUCCEEDED":
+            print(f"  ✓ Image mirrored to ECR: {ecr_uri}")
+            return ecr_uri
+        if status in ("FAILED", "FAULT", "STOPPED", "TIMED_OUT"):
+            logs = resp["builds"][0].get("logs", {}).get("deepLink", "")
+            print(f"  ✗ CodeBuild {status}. Logs: {logs}")
+            sys.exit(1)
+        time.sleep(15)
+    print("  ✗ CodeBuild timed out")
+    sys.exit(1)
+
+
+def _ensure_codebuild_role(iam, account):
+    """Create or return the CodeBuild service role for image mirroring."""
+    role_name = "bench-codebuild-mirror-role"
+    try:
+        return iam.get_role(RoleName=role_name)["Role"]["Arn"]
+    except iam.exceptions.NoSuchEntityException:
+        pass
+
+    trust = json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "Allow", "Principal": {"Service": "codebuild.amazonaws.com"}, "Action": "sts:AssumeRole"}]
+    })
+    role = iam.create_role(RoleName=role_name, AssumeRolePolicyDocument=trust)
+    iam.attach_role_policy(RoleName=role_name, PolicyArn="arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser")
+    iam.attach_role_policy(RoleName=role_name, PolicyArn="arn:aws:iam::aws:policy/CloudWatchLogsFullAccess")
+    time.sleep(10)  # wait for role propagation
+    return role["Role"]["Arn"]
+
+
+# --- Deployment (boto3) ---
+
+def get_client(region=None):
+    return boto3.client("sagemaker", region_name=region or REGION,
+                        config=boto3.session.Config(parameter_validation=False))
+
+
+def get_role_arn():
+    """Get the SageMaker execution role from environment."""
+    role = os.environ.get("SAGEMAKER_ROLE_ARN")
+    if not role:
+        raise ValueError("No role ARN configured. Set 'role_arn' in sagemaker_defaults or SAGEMAKER_ROLE_ARN env var.")
+    return role
+
+
+def endpoint_name(model_key):
+    return f"bench-{model_key}"[:63]
+
+
+def ic_name(model_key):
+    return f"bench-ic-{model_key}"[:63]
+
+
+def deploy_model(client, model_key, model_cfg, defaults):
+    """Deploy using the AWS vLLM SageMaker DLC.
+    Uses SM_VLLM_* env vars which map directly to vLLM CLI args.
+    Image is already in ECR — no build needed.
+    """
+    ep_name = endpoint_name(model_key)
+    ep_config_name = f"{ep_name}-config"
+    sm_model_name = f"bench-mdl-{model_key}"[:63]
+    role = defaults.get("role_arn") or get_role_arn()
+    instance_type = model_cfg["instance_type"]
+    num_gpus = model_cfg.get("num_gpus", 1)
+    region = defaults.get("region", REGION)
+    image = defaults["sagemaker_image"].format(region=region)
+    ami_version = defaults.get("inference_ami_version", "al2-ami-sagemaker-inference-gpu-3-1")
+    training_plan_arn = defaults.get("ml_reservation_arn")
+    model_id = model_cfg["model_name"]
+    s3_model_uri = model_cfg.get("s3_model_uri", "")
+
+    env_vars = {
+        "SM_VLLM_TENSOR_PARALLEL_SIZE": str(num_gpus),
+        "SM_VLLM_TRUST_REMOTE_CODE": "true",
+    }
+    # When s3_model_uri is set, use ModelDataSource (SageMaker mounts to /opt/ml/model)
+    # Otherwise, use SM_VLLM_MODEL with the HuggingFace ID
+    if not s3_model_uri:
+        env_vars["SM_VLLM_MODEL"] = model_id
+    vllm_config = defaults.get("vllm_config", {})
+    if vllm_config.get("max_model_len"):
+        env_vars["SM_VLLM_MAX_MODEL_LEN"] = str(vllm_config["max_model_len"])
+    if vllm_config.get("gpu_memory_utilization"):
+        env_vars["SM_VLLM_GPU_MEMORY_UTILIZATION"] = str(vllm_config["gpu_memory_utilization"])
+    # Allow per-model overrides
+    for k, v in model_cfg.get("env", {}).items():
+        env_vars[k] = str(v)
+    hf_token = os.environ.get("HF_TOKEN")
+    if hf_token:
+        env_vars["HF_TOKEN"] = hf_token
+
+    print(f"\n{'='*60}")
+    print(f"[deploy] {model_key}")
+    print(f"  image: {image}")
+    print(f"  instance: {instance_type} ({num_gpus} GPUs)")
+    print(f"  model: {model_id}")
+    if s3_model_uri:
+        print(f"  source: {s3_model_uri} (S3)")
+    else:
+        print(f"  source: HuggingFace (direct download)")
+    print(f"{'='*60}")
+
+    # 1. Create Model
+    try:
+        client.delete_model(ModelName=sm_model_name)
+    except Exception:
+        pass
+    container_def = {
+        "Image": image,
+        "Environment": env_vars,
+    }
+    if s3_model_uri:
+        container_def["ModelDataSource"] = {
+            "S3DataSource": {
+                "S3Uri": s3_model_uri,
+                "S3DataType": "S3Prefix",
+                "CompressionType": "None",
+            }
+        }
+    client.create_model(
+        ModelName=sm_model_name,
+        ExecutionRoleArn=role,
+        PrimaryContainer=container_def,
+    )
+    print(f"  ✓ Created model: {sm_model_name}")
+
+    # 2. Create endpoint config (with training plan for capacity)
+    try:
+        client.delete_endpoint_config(EndpointConfigName=ep_config_name)
+    except Exception:
+        pass
+    variant = {
+        "VariantName": "default",
+        "ModelName": sm_model_name,
+        "InstanceType": instance_type,
+        "InitialInstanceCount": 1,
+        "InferenceAmiVersion": ami_version,
+        "ModelDataDownloadTimeoutInSeconds": 1800,
+        "ContainerStartupHealthCheckTimeoutInSeconds": 1800,
+    }
+    if training_plan_arn:
+        variant["CapacityReservationConfig"] = {
+            "MlReservationArn": training_plan_arn,
+            "CapacityReservationPreference": "capacity-reservations-only",
+        }
+    client.create_endpoint_config(
+        EndpointConfigName=ep_config_name,
+        ProductionVariants=[variant],
+    )
+    print(f"  ✓ Created endpoint config: {ep_config_name}")
+
+    # 3. Create or update endpoint
+    try:
+        client.create_endpoint(
+            EndpointName=ep_name,
+            EndpointConfigName=ep_config_name,
+        )
+        print(f"  ✓ Created endpoint: {ep_name}")
+    except client.exceptions.ClientError as e:
+        if "Cannot create already existing" in str(e):
+            client.update_endpoint(EndpointName=ep_name, EndpointConfigName=ep_config_name)
+            print(f"  → Updated endpoint: {ep_name}")
+        else:
+            raise
+
+    # 4. Wait for InService
+    print(f"  ⏳ Waiting for endpoint InService...")
+    waiter = client.get_waiter("endpoint_in_service")
+    try:
+        waiter.wait(EndpointName=ep_name, WaiterConfig={"Delay": 30, "MaxAttempts": 60})
+    except Exception as e:
+        status = client.describe_endpoint(EndpointName=ep_name)["EndpointStatus"]
+        return {"success": False, "error": f"Endpoint stuck in {status}: {e}"}
+
+    print(f"  ✓ Endpoint InService: {ep_name}")
+    return {"success": True, "endpoint": ep_name, "model_name": sm_model_name}
+
+
+# --- Inference Recommender (Advanced) ---
+
+def run_recommendation_job(client, model_key, model_cfg, ep_name, defaults):
+    """Run an Advanced Inference Recommender job with staircase traffic pattern.
+    Tests concurrency scaling and can optionally tune vLLM env vars.
+    """
+    role = get_role_arn()
+    sm_model_name = f"bench-mdl-{model_key}"[:63]
+    job_name = f"reco-{model_key}-{int(time.time())}"[:63]
+    model_id = model_cfg["model_name"]
+
+    print(f"\n{'='*60}")
+    print(f"[recommendation] {model_key}")
+    print(f"  endpoint: {ep_name}")
+    print(f"  model: {model_id}")
+    print(f"{'='*60}")
+
+    try:
+        client.create_inference_recommendations_job(
+            JobName=job_name,
+            JobType="Advanced",
+            RoleArn=role,
+            InputConfig={
+                "ModelName": sm_model_name,
+                "Endpoints": [{"EndpointName": ep_name}],
+                "JobDurationInSeconds": 600,
+                "TrafficPattern": {
+                    "TrafficType": "STAIRS",
+                    "Stairs": {
+                        "DurationInSeconds": 120,
+                        "NumberOfSteps": 5,
+                        "UsersPerStep": 16,
+                    },
+                },
+                "TokenizerConfig": {
+                    "ModelId": model_id,
+                    "AcceptEula": True,
+                },
+            },
+            StoppingConditions={
+                "MaxInvocations": 5000,
+            },
+        )
+        print(f"  ✓ Created recommendation job: {job_name}")
+    except Exception as e:
+        print(f"  ✗ Failed to create recommendation job: {e}")
+        return {"success": False, "error": str(e), "gap": classify_gap(str(e))}
+
+    # Poll for completion
+    print(f"  ⏳ Polling (every 30s, up to 30 min)...")
+    for _ in range(60):
+        resp = client.describe_inference_recommendations_job(JobName=job_name)
+        status = resp["Status"]
+        if status == "COMPLETED":
+            results = resp.get("InferenceRecommendations", [])
+            print(f"  ✓ Completed — {len(results)} recommendation(s)")
+            return {"success": True, "status": "completed", "job_name": job_name, "recommendations": results}
+        if status in ("FAILED", "STOPPED"):
+            reason = resp.get("FailureReason", "unknown")
+            print(f"  ✗ {status}: {reason}")
+            return {"success": False, "error": reason, "gap": classify_gap(reason)}
+        time.sleep(30)
+    return {"success": False, "error": "Recommendation job timed out", "gap": {"category": "timeout"}}
+
+
+# --- Benchmarking (boto3) ---
+
+def run_benchmark_job(client, job, ep_name, defaults, models=None):
+    """Create a workload config and benchmark job for a single concurrency level."""
+    role = defaults.get("role_arn") or get_role_arn()
+    s3_output = defaults.get("s3_output", "").format(region=REGION)
+    if not s3_output:
+        account = boto3.client("sts", region_name="us-east-2").get_caller_identity()["Account"]
+        s3_output = f"s3://sagemaker-benchmark-{REGION}-{account}/managed-inference"
+
+    # Hierarchical path: {env}/{model}/{workload}/{instance}/{timestamp}/
+    instance_short = defaults.get("ml_reservation_arn", "").split("/")[-1][:8] or "p6-b200"
+    timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
+    s3_job_path = f"{s3_output}/{job['model_key']}/{job['workload_key']}/p6-b200-c{job['concurrency']}/{timestamp}/"
+
+    ts = datetime.now().strftime("%m%d%H%M")
+    job_name = f"{job['id'][:50]}-{ts}".replace("_", "-")
+    config_name = f"wl-{job['workload_key']}-c{job['concurrency']}"[:63].replace("_", "-")
+
+    print(f"\n{'─'*60}")
+    print(f"[benchmark] {job['id']}")
+    print(f"  concurrency={job['concurrency']} in={job['input_tokens']} out={job['output_tokens']}")
+    print(f"{'─'*60}")
+
+    # Build workload spec
+    workload_spec = {
+        "benchmark": {"type": "aiperf"},
+        "parameters": {
+            "tokenizer": job.get("benchmark_tokenizer") or job["model_name"],
+            "concurrency": job["concurrency"],
+            "prompt_input_tokens_mean": job["input_tokens"],
+            "prompt_input_tokens_stddev": 0,
+            "output_tokens_mean": job["output_tokens"],
+            "output_tokens_stddev": 0,
+            "streaming": job["streaming"],
+            "benchmark_duration": job["duration"],
+            "warmup_duration": job["warmup"],
+            "extra_inputs": "ignore_eos:true temperature:0",
+        },
+        "tooling": {"api_standard": "openai"},
+    }
+    if job.get("dataset"):
+        workload_spec["parameters"]["public_dataset"] = job["dataset"]
+
+    hf_secret = os.environ.get("HF_TOKEN_SECRET_ARN")
+    if hf_secret:
+        workload_spec["secrets"] = {"hf_token": hf_secret}
+
+    # Create or update workload config
+    try:
+        client.delete_ai_workload_config(AIWorkloadConfigName=config_name)
+    except Exception:
+        pass
+    try:
+        client.create_ai_workload_config(
+            AIWorkloadConfigName=config_name,
+            AIWorkloadConfigs={"WorkloadSpec": {"Inline": json.dumps(workload_spec)}},
+        )
+        print(f"  ✓ Created workload config: {config_name}")
+    except Exception as e:
+        print(f"  ✗ Failed to create workload config: {e}")
+        return {"success": False, "error": f"Failed to create workload config: {e}", "gap": classify_gap(str(e))}
+
+    # Delete previous job with same name if exists
+    try:
+        client.delete_ai_benchmark_job(AIBenchmarkJobName=job_name)
+    except Exception:
+        pass
+
+    # Create benchmark job
+    try:
+        client.create_ai_benchmark_job(
+            AIBenchmarkJobName=job_name,
+            AIWorkloadConfigIdentifier=config_name,
+            BenchmarkTarget={
+                "Endpoint": {
+                    "Identifier": ep_name,
+                }
+            },
+            OutputConfig={"S3OutputLocation": s3_job_path},
+            RoleArn=role,
+            Tags=[
+                {"Key": "project", "Value": "benchmarking-initiative"},
+                {"Key": "environment", "Value": "managed-inference"},
+                {"Key": "model", "Value": job["model_key"]},
+                {"Key": "workload", "Value": job["workload_key"]},
+                {"Key": "concurrency", "Value": str(job["concurrency"])},
+                {"Key": "instance-type", "Value": job["instance_type"]},
+                {"Key": "ml-reservation-arn", "Value": defaults.get("ml_reservation_arn", "")},
+            ],
+        )
+        print(f"  ✓ Created benchmark job: {job_name}")
+
+        # Write manifest describing benchmark conditions
+        manifest = {
+            "model": job["model_name"],
+            "model_key": job["model_key"],
+            "workload": job["workload_key"],
+            "concurrency": job["concurrency"],
+            "input_tokens": job["input_tokens"],
+            "output_tokens": job["output_tokens"],
+            "streaming": job["streaming"],
+            "duration": job["duration"],
+            "instance_type": "ml.p6-b200.48xlarge",
+            "num_gpus": job["num_gpus"],
+            "vllm_config": defaults.get("vllm_config", {}),
+            "image": defaults.get("sagemaker_image", "").format(region=REGION),
+            "timestamp": timestamp,
+            "environment": "managed-inference",
+        }
+        s3_parts = s3_job_path.replace("s3://", "").split("/", 1)
+        s3_client = boto3.client("s3", region_name=REGION)
+        try:
+            s3_client.put_object(
+                Bucket=s3_parts[0],
+                Key=f"{s3_parts[1]}manifest.json",
+                Body=json.dumps(manifest, indent=2),
+                ContentType="application/json",
+            )
+        except Exception:
+            pass  # non-fatal
+    except Exception as e:
+        return {"success": False, "error": f"Failed to create benchmark job: {e}", "gap": classify_gap(str(e))}
+
+    # Poll for completion
+    print(f"  ⏳ Polling (every 30s, up to 30 min)...")
+    for i in range(60):
+        resp = client.describe_ai_benchmark_job(AIBenchmarkJobName=job_name)
+        status = resp["AIBenchmarkJobStatus"]
+        if status == "Completed":
+            s3_loc = resp["OutputConfig"]["S3OutputLocation"]
+            print(f"  ✓ Completed — results at {s3_loc}")
+            from athena_writer import write_athena_record
+            model_cfg = (models or {}).get(job["model_key"], {})
+            write_athena_record({
+                "job_id": job_name,
+                "environment": "managed-inference",
+                "model_key": job["model_key"],
+                "model_name": job["model_name"],
+                "workload": job["workload_key"],
+                "concurrency": job["concurrency"],
+                "input_tokens": job["input_tokens"],
+                "output_tokens": job["output_tokens"],
+                "streaming": job["streaming"],
+                "duration": job["duration"],
+                "warmup": job["warmup"],
+                "instance_type": job["instance_type"],
+                "num_gpus": job["num_gpus"],
+                "dataset": job.get("dataset"),
+                "vllm_config": defaults.get("vllm_config", {}),
+                "source_region": REGION,
+                "s3_output": s3_loc,
+                "timestamp": timestamp,
+            }, model_config=model_cfg, defaults_config=defaults, config_source="benchmarks.yaml")
+            return {"success": True, "status": "completed", "s3_output": s3_loc}
+        if status in ("Failed", "Stopped"):
+            reason = resp.get("FailureReason", "unknown")
+            print(f"  ✗ {status}: {reason}")
+            return {"success": False, "error": reason, "gap": classify_gap(reason)}
+        time.sleep(30)
+    return {"success": False, "error": "Benchmark timed out after 30 min", "gap": {"category": "timeout"}}
+
+
+# --- Gap Classification ---
+
+def classify_gap(error_str):
+    err = str(error_str).lower()
+    if "unrecognizedclient" in err:
+        return {"category": "api_availability", "action": "Confirm API availability in us-west-2"}
+    if "capacity" in err or "resourcelimit" in err:
+        return {"category": "capacity", "action": "Request capacity or try different instance"}
+    if "tokenizer" in err or "hf_token" in err or "access" in err:
+        return {"category": "model_access", "action": "Set HF_TOKEN or HF_TOKEN_SECRET_ARN"}
+    if "timeout" in err:
+        return {"category": "timeout", "action": "Increase timeout or reduce concurrency"}
+    if "throttl" in err:
+        return {"category": "throttling", "action": "Add backoff or reduce request rate"}
+    return {"category": "unknown", "detail": error_str[:300]}
+
+
+# --- Cleanup ---
+
+def cleanup_model(client, model_key):
+    """Delete endpoint, endpoint config, and model."""
+    ep_name = endpoint_name(model_key)
+    ep_config_name = f"{ep_name}-config"
+    sm_model_name = f"bench-mdl-{model_key}"[:63]
+
+    print(f"\n[cleanup] {model_key}")
+    try:
+        client.delete_endpoint(EndpointName=ep_name)
+        print(f"  ✓ Deleted endpoint: {ep_name}")
+    except Exception:
+        pass
+    try:
+        client.delete_endpoint_config(EndpointConfigName=ep_config_name)
+        print(f"  ✓ Deleted endpoint config: {ep_config_name}")
+    except Exception:
+        pass
+    try:
+        client.delete_model(ModelName=sm_model_name)
+        print(f"  ✓ Deleted model: {sm_model_name}")
+    except Exception:
+        pass
+
+
+def wait_for_ftp_available(client, defaults):
+    """Poll the training plan until the reserved capacity instance is available."""
+    training_plan_arn = defaults.get("ml_reservation_arn", "")
+    if not training_plan_arn:
+        time.sleep(60)
+        return
+    plan_name = training_plan_arn.split("/")[-1]
+    region = defaults.get("region", "us-east-2")
+    sm = boto3.client("sagemaker", region_name=region)
+
+    print(f"  ⏳ Waiting for FTP instance to become available...")
+    for attempt in range(120):  # up to 60 min
+        try:
+            resp = sm.describe_training_plan(TrainingPlanName=plan_name)
+            available = resp.get("AvailableInstanceCount", 0)
+            total = resp.get("TotalInstanceCount", 1)
+            if available >= 1:
+                print(f"  ✓ FTP available ({available}/{total} instances free)")
+                return
+            print(f"    [{(attempt+1)*30}s] FTP in use ({available}/{total} available)")
+        except Exception as e:
+            print(f"    [{(attempt+1)*30}s] Could not check FTP: {e}")
+        time.sleep(30)
+    print(f"  ⚠️  FTP not available after 60 min — proceeding anyway")
+
+
+# --- Remote Execution (Processing Job) ---
+
+def submit_processing_job(args, script_name, job_prefix, config_path):
+    """Submit this script as a SageMaker Processing Job for unattended execution."""
+    config = load_config(config_path)
+    defaults = config.get("sagemaker_defaults", {})
+    region = defaults.get("region", "us-east-2")
+    role = defaults.get("role_arn")
+    if not role:
+        raise ValueError("'role_arn' must be set in sagemaker_defaults")
+    s3_output = defaults.get("s3_output", "").format(region=region)
+    bucket = s3_output.replace("s3://", "").split("/")[0] if s3_output else f"sagemaker-benchmark-{region}-{boto3.client('sts', region_name=region).get_caller_identity()['Account']}"
+    job_name = f"{job_prefix}-{datetime.now().strftime('%m%d-%H%M')}"[:63]
+
+    sm = boto3.client("sagemaker", region_name=region)
+    s3 = boto3.client("s3", region_name="us-east-2")
+
+    # Upload script + config + requirements + athena_writer (all under same prefix)
+    prefix = f"processing-configs/{job_name}"
+    script_dir = os.path.dirname(script_name)
+    s3.put_object(Bucket=bucket, Key=f"{prefix}/script.py", Body=open(script_name).read())
+    s3.put_object(Bucket=bucket, Key=f"{prefix}/benchmarks.yaml", Body=open(config_path).read())
+    req_path = os.path.join(script_dir, "requirements.txt")
+    if os.path.exists(req_path):
+        s3.put_object(Bucket=bucket, Key=f"{prefix}/requirements.txt", Body=open(req_path).read())
+    athena_path = os.path.join(script_dir, "athena_writer.py")
+    if os.path.exists(athena_path):
+        s3.put_object(Bucket=bucket, Key=f"{prefix}/athena_writer.py", Body=open(athena_path).read())
+
+    # Build container args (pass through filters)
+    container_args = []
+    if args.model:
+        container_args += ["--model", args.model]
+    if args.workload:
+        container_args += ["--workload", args.workload]
+    if hasattr(args, 'endpoint') and args.endpoint:
+        container_args += ["--endpoint", args.endpoint]
+
+    print(f"\n{'='*60}")
+    print(f"Submitting Processing Job: {job_name}")
+    print(f"  Region: {region}")
+    print(f"  Instance: ml.m7i.4xlarge (Intel)")
+    print(f"  Max runtime: 5 days")
+    if args.model:
+        print(f"  Filter: --model={args.model}")
+    print(f"{'='*60}\n")
+
+    sm.create_processing_job(
+        ProcessingJobName=job_name,
+        ProcessingResources={
+            "ClusterConfig": {
+                "InstanceCount": 1,
+                "InstanceType": "ml.m7i.4xlarge",
+                "VolumeSizeInGB": 50,
+            }
+        },
+        AppSpecification={
+            "ImageUri": f"763104351884.dkr.ecr.{region}.amazonaws.com/pytorch-training:2.5.1-cpu-py311",
+            "ContainerEntrypoint": ["python3", "/opt/ml/processing/input/script/script.py"],
+            "ContainerArguments": ["/opt/ml/processing/input/script/benchmarks.yaml"] + container_args,
+        },
+        ProcessingInputs=[
+            {
+                "InputName": "script",
+                "S3Input": {
+                    "S3Uri": f"s3://{bucket}/{prefix}/",
+                    "LocalPath": "/opt/ml/processing/input/script",
+                    "S3DataType": "S3Prefix",
+                    "S3InputMode": "File",
+                },
+            },
+        ],
+        ProcessingOutputConfig={
+            "Outputs": [{
+                "OutputName": "results",
+                "S3Output": {
+                    "S3Uri": f"s3://{bucket}/processing-results/{job_name}/",
+                    "LocalPath": "/opt/ml/processing/output",
+                    "S3UploadMode": "EndOfJob",
+                },
+            }]
+        },
+        RoleArn=role,
+        StoppingCondition={"MaxRuntimeInSeconds": 432000},  # 5 days
+        NetworkConfig={"EnableNetworkIsolation": False},
+    )
+
+    print(f"  ✓ Job submitted: {job_name}")
+    print(f"  Monitor: aws sagemaker describe-processing-job --processing-job-name {job_name} --region {region}")
+
+
+# --- Main ---
+
+def main():
+    # Upgrade dependencies if running inside a Processing Job (DLC has old SDK)
+    if os.environ.get("PROCESSING_JOB_NAME") or os.path.exists("/opt/ml/processing"):
+        if not os.environ.get("_DEPS_INSTALLED"):
+            import subprocess
+            subprocess.run(["pip", "install", "-q", "-r", "/opt/ml/processing/input/script/requirements.txt"])
+            # Re-exec with updated packages
+            os.environ["_DEPS_INSTALLED"] = "1"
+            os.execv(sys.executable, [sys.executable] + sys.argv)
+
+    parser = argparse.ArgumentParser(
+        description="SageMaker Managed Inference benchmarking using AI Benchmarking (NVIDIA AIPerf).",
+        epilog="""
+examples:
+  %(prog)s --validate                    Show expanded job matrix without running
+  %(prog)s                               Run all benchmarks (deploy + benchmark)
+  %(prog)s --model=gemma                 Run only models matching 'gemma'
+  %(prog)s --workload=rag               Run only workloads matching 'rag'
+  %(prog)s --deploy-only                 Deploy endpoints, skip benchmarking
+  %(prog)s --benchmark-only              Benchmark existing endpoints (skip deploy)
+  %(prog)s --cleanup                     Delete all deployed endpoints
+  %(prog)s --submit                      Submit as unattended Processing Job (5-day timeout)
+  %(prog)s --submit --model=gemma        Submit filtered job remotely
+
+config: reads from benchmarks.yaml (models, workloads, sagemaker_defaults, sagemaker_benchmarks)
+output: results written to S3 and local results/ directory
+resume: re-run safely — completed jobs are skipped automatically
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("config", nargs="?", default="../benchmarks.yaml", help="Path to benchmarks.yaml config (default: ../benchmarks.yaml)")
+    parser.add_argument("--validate", action="store_true", help="Show expanded job matrix and exit (no AWS calls)")
+    parser.add_argument("--model", help="Filter by model key substring (e.g. 'gemma', 'qwen3')")
+    parser.add_argument("--workload", help="Filter by workload key substring (e.g. 'rag', 'chat')")
+    parser.add_argument("--deploy-only", action="store_true", help="Deploy model endpoints only, skip benchmarking")
+    parser.add_argument("--benchmark-only", action="store_true", help="Run benchmarks against already-deployed endpoints")
+    parser.add_argument("--endpoint", help="Run benchmarks against this specific endpoint name (skips deploy/cleanup, requires --model)")
+    parser.add_argument("--cleanup", action="store_true", help="Delete all deployed endpoints and models")
+    parser.add_argument("--submit", action="store_true", help="Submit as a remote SageMaker Processing Job (no credential expiry, 5-day timeout)")
+    args = parser.parse_args()
+
+    if args.submit:
+        submit_processing_job(args, __file__, "bench-smai", args.config)
+        return
+
+    config = load_config(args.config)
+    jobs = expand_jobs(config, args.model, args.workload)
+
+    if args.validate:
+        models = sorted(set(j["model_key"] for j in jobs))
+        workloads = sorted(set(j["workload_key"] for j in jobs))
+        print(f"Expanded {len(jobs)} job(s)\n")
+        print(f"Models ({len(models)}):")
+        for m in models:
+            mc = config["models"][m]
+            print(f"  ✓ {m} ({mc['instance_type']}, {mc.get('num_gpus',1)} GPUs)")
+        print(f"\nWorkloads ({len(workloads)}):")
+        for w in workloads:
+            wl = config["workloads"][w]
+            print(f"  ✓ {w}: in={wl['input_tokens']} out={wl['output_tokens']} c=[{','.join(map(str, wl['concurrency']))}]")
+        print(f"\nTotal jobs: {len(jobs)}")
+        return
+
+    client = get_client(config.get("sagemaker_defaults", {}).get("region"))
+
+    # Set global region from config
+    global REGION
+    REGION = config.get("sagemaker_defaults", {}).get("region", REGION)
+
+    # Ensure S3 bucket for benchmark output exists
+    defaults_cfg = config.get("sagemaker_defaults", {})
+    s3_output = defaults_cfg.get("s3_output", "").format(region=REGION)
+    if s3_output:
+        s3_bucket = s3_output.replace("s3://", "").split("/")[0]
+    else:
+        account = boto3.client("sts", region_name="us-east-2").get_caller_identity()["Account"]
+        s3_bucket = f"sagemaker-benchmark-{REGION}-{account}"
+    s3 = boto3.client("s3", region_name=REGION)
+    try:
+        s3.head_bucket(Bucket=s3_bucket)
+    except Exception:
+        try:
+            s3.create_bucket(Bucket=s3_bucket, CreateBucketConfiguration={"LocationConstraint": REGION})
+            print(f"  ✓ Created S3 bucket: {s3_bucket}")
+        except Exception:
+            pass
+
+    if args.cleanup:
+        models = sorted(set(j["model_key"] for j in jobs))
+        for m in models:
+            cleanup_model(client, m)
+        return
+
+    # Group jobs by model
+    by_model = {}
+    for j in jobs:
+        by_model.setdefault(j["model_key"], []).append(j)
+
+    run_id = "sagemaker-latest"
+    run_dir = RESULTS_DIR / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    results = []
+    gaps = []
+
+    for model_key, model_jobs in by_model.items():
+        model_cfg = config["models"][model_key]
+
+        # Use explicit endpoint if provided (skips deploy/cleanup)
+        if args.endpoint:
+            ep_name_val = args.endpoint
+        elif not args.benchmark_only:
+            deploy_result = deploy_model(client, model_key, model_cfg, config.get("sagemaker_defaults", {}))
+            if not deploy_result["success"]:
+                gap = classify_gap(deploy_result.get("error", ""))
+                gaps.append({"model": model_key, "step": "deploy", **gap})
+                print(f"  ✗ Deploy failed — skipping all workloads for {model_key}")
+                for j in model_jobs:
+                    results.append({"id": j["id"], "status": "skipped", "reason": deploy_result["error"]})
+                # Cleanup failed endpoint before moving to next model
+                cleanup_model(client, model_key)
+                wait_for_ftp_available(client, config.get("sagemaker_defaults", {}))
+                continue
+            ep_name_val = endpoint_name(model_key)
+        else:
+            ep_name_val = endpoint_name(model_key)
+
+        if args.deploy_only:
+            continue
+
+        # Run benchmarks
+        for job in model_jobs:
+            # Resume logic: skip jobs that already completed
+            result_file = run_dir / f"{job['id']}.json"
+            if result_file.exists():
+                existing = json.loads(result_file.read_text())
+                if existing.get("success"):
+                    print(f"\n  ⏭️  Skipping {job['id']} (already completed)")
+                    results.append(existing)
+                    continue
+
+            result = run_benchmark_job(client, job, ep_name_val, config.get("sagemaker_defaults", {}), models=config.get("models", {}))
+            result["id"] = job["id"]
+            result["model_key"] = job["model_key"]
+            result["workload_key"] = job["workload_key"]
+            result["concurrency"] = job["concurrency"]
+            results.append(result)
+            # Write per-job result
+            (run_dir / f"{job['id']}.json").write_text(json.dumps(result, indent=2, default=str))
+            if result.get("gap"):
+                gaps.append({"model": model_key, "job": job["id"], **result["gap"]})
+
+        # Cleanup after all workloads for this model (required for single-instance FTP)
+        if config.get("sagemaker_defaults", {}).get("cleanup", False) and not args.benchmark_only and not args.endpoint:
+            cleanup_model(client, model_key)
+            wait_for_ftp_available(client, config.get("sagemaker_defaults", {}))
+
+    # Write summary
+    summary = {"run_id": run_id, "total": len(results),
+               "completed": sum(1 for r in results if r.get("success")),
+               "failed": sum(1 for r in results if not r.get("success") and r.get("status") != "skipped"),
+               "skipped": sum(1 for r in results if r.get("status") == "skipped"),
+               "gaps": gaps, "results": results}
+    (run_dir / "summary.json").write_text(json.dumps(summary, indent=2, default=str))
+    if gaps:
+        (run_dir / "gaps.json").write_text(json.dumps(gaps, indent=2, default=str))
+
+    # Print summary
+    print(f"\n{'═'*60}")
+    print("BENCHMARK RUN SUMMARY")
+    print(f"{'═'*60}")
+    print(f"Run ID: {run_id}")
+    print(f"Total: {summary['total']} | Completed: {summary['completed']} | Failed: {summary['failed']} | Skipped: {summary['skipped']}")
+    if gaps:
+        print(f"\nGAPS ({len(gaps)}):")
+        for g in gaps:
+            print(f"  [{g.get('category','?')}] {g.get('model','')}: {g.get('action', g.get('detail',''))}")
+    print(f"\nResults: {run_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/07-benchmark/autobench/sdk/benchmark_bedrock_byom.py
+++ b/07-benchmark/autobench/sdk/benchmark_bedrock_byom.py
@@ -1,0 +1,661 @@
+#!/usr/bin/env python3
+"""
+Bedrock BYOM (Bring Your Own Model) benchmarking via Processing Job.
+
+Submits a long-running Processing Job that:
+1. Downloads model weights from HuggingFace
+2. Uploads to S3 under byom/ prefix
+3. Imports via Mantle API
+4. Creates RU reservation
+5. Submits benchmark jobs via AI Benchmarking (direct-URL)
+
+Usage:
+    python benchmark_bedrock_byom.py --submit --model=gpt-oss-120b-byom
+    python benchmark_bedrock_byom.py --validate
+    python benchmark_bedrock_byom.py --import-only --model=gpt-oss-120b-byom
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+import boto3
+import yaml
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+
+RESULTS_DIR = Path("results")
+DIRECT_URL_SENTINEL = "bench-direct-7f2a9c4e1b8d053f6a9e2c7d4b1f8a3e5d0c6b9a4e8f2a1d"
+ENTRYPOINT_MODE = os.environ.get("SM_PROCESSING_MODE") == "byom-benchmark"
+
+
+def load_config(path="../benchmarks.yaml"):
+    if ENTRYPOINT_MODE:
+        path = "/opt/ml/processing/input/script/benchmarks.yaml"
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def expand_byom_jobs(config, model_filter=None, workload_filter=None):
+    """Expand byom_benchmarks into individual jobs."""
+    defaults = config.get("byom_defaults", {})
+    # BYOM now reads from the shared models section (byom: sub-key)
+    models = config.get("models") or {}
+    workloads = config.get("workloads", {})
+    benchmarks = config.get("byom_benchmarks") or []
+    jobs = []
+
+    for bench in benchmarks:
+        model_key = bench["model"]
+        model = models.get(model_key)
+        if not model:
+            print(f"ERROR: Unknown byom model '{model_key}'", file=sys.stderr)
+            sys.exit(1)
+        byom = model.get("byom")
+        if not byom:
+            print(f"SKIP: Model '{model_key}' has no byom config — not BYOM-supported", file=sys.stderr)
+            continue
+        if model_filter and model_filter not in model_key:
+            continue
+        for wl_name in bench["workloads"]:
+            if workload_filter and workload_filter not in wl_name:
+                continue
+            workload = workloads.get(wl_name)
+            if not workload:
+                print(f"ERROR: Unknown workload '{wl_name}'", file=sys.stderr)
+                sys.exit(1)
+            for concurrency in workload["concurrency"]:
+                jobs.append({
+                    "id": f"byom-{model_key}--{wl_name}--c{concurrency}",
+                    "model_key": model_key,
+                    "base_model_id": byom["base_model_id"],
+                    "tokenizer": model.get("benchmark_tokenizer", model["model_name"]),
+                    "model_id": byom.get("model_id", ""),
+                    "workload_key": wl_name,
+                    "concurrency": concurrency,
+                    "input_tokens": workload["input_tokens"],
+                    "output_tokens": workload["output_tokens"],
+                    "streaming": workload.get("streaming", True),
+                    "duration": workload.get("duration", 300),
+                    "warmup": workload.get("warmup", 30),
+                })
+    return jobs
+
+
+# --- Mantle API Client ---
+
+def mantle_request(method, path, defaults, body=None):
+    """Make a SigV4-signed request to the Mantle API."""
+    endpoint = defaults.get("mantle_endpoint", f"https://bedrock-mantle.{defaults['region']}.api.aws")
+    endpoint = endpoint.format(region=defaults["region"])
+    region = defaults["region"]
+    url = f"{endpoint}{path}"
+
+    session = boto3.Session()
+    credentials = session.get_credentials().get_frozen_credentials()
+
+    headers = {"Content-Type": "application/json"}
+    data = json.dumps(body) if body else None
+
+    request = AWSRequest(method=method, url=url, data=data, headers=headers)
+    SigV4Auth(credentials, "bedrock-mantle", region).add_auth(request)
+
+    import urllib.request
+    req = urllib.request.Request(
+        url,
+        data=data.encode() if data else None,
+        headers=dict(request.headers),
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode() if e.fp else ""
+        print(f"  ✗ Mantle API {method} {path} → {e.code}: {error_body}")
+        return None
+
+
+def check_weights_in_s3(model_key, model_cfg, defaults):
+    """Verify model weights exist in S3. Returns the S3 URI or None."""
+    # Use explicit s3_model_uri if set in config
+    s3_uri = model_cfg.get("s3_model_uri", "")
+    if s3_uri:
+        print(f"  ✓ Using s3_model_uri: {s3_uri}")
+        return s3_uri
+
+    print(f"  ✗ No s3_model_uri set for {model_key}")
+    print(f"    1. Run: python download_models.py --region {defaults['region']} --model=<model>")
+    print(f"    2. Set s3_model_uri in models.{model_key} in benchmarks.yaml")
+    return None
+
+
+def import_model(model_key, model_cfg, defaults):
+    """Import model via Mantle customization API. Returns model_id."""
+    print(f"\n  📦 Importing {model_key} via BYOM...")
+    weights_uri = model_cfg["weights_s3_uri"]
+    # Mantle expects the index file path, not the directory
+    if not weights_uri.endswith(".json"):
+        weights_uri = weights_uri.rstrip("/") + "/model.safetensors.index.json"
+    body = {
+        "base_model_id": model_cfg["byom"]["base_model_id"],
+        "model_config": {
+            "source": {
+                "type": "s3",
+                "weights_index_s3_uri": weights_uri,
+            },
+        },
+    }
+    resp = mantle_request("POST", "/bedrock/v1/models/customization", defaults, body)
+    if not resp:
+        return None
+    model_id = resp.get("model_id") or resp.get("modelId") or resp.get("id")
+    print(f"  ✓ Import started: model_id={model_id}")
+    return model_id
+
+
+def poll_import(model_id, defaults, timeout_minutes=30):
+    """Poll until model import completes."""
+    print(f"  ⏳ Polling import status (timeout={timeout_minutes}min)...")
+    for i in range(timeout_minutes * 2):  # poll every 30s
+        resp = mantle_request("GET", f"/bedrock/v1/models/customization/{model_id}", defaults)
+        if not resp:
+            time.sleep(30)
+            continue
+        status = resp.get("status", resp.get("Status", ""))
+        if status.lower() in ("complete", "completed", "active", "ready"):
+            print(f"  ✓ Import complete: {model_id}")
+            return True
+        if status.lower() in ("failed", "error"):
+            print(f"  ✗ Import failed: {resp}")
+            return False
+        elapsed = (i + 1) * 30
+        print(f"    [{elapsed}s] status={status}")
+        time.sleep(30)
+    print(f"  ✗ Import timed out after {timeout_minutes}min")
+    return False
+
+
+def create_reservation(model_id, defaults):
+    """Create an RU reservation for the model. Returns reservation_id."""
+    ru_count = defaults.get("default_ru_count", 1)
+    print(f"  🔒 Creating reservation ({ru_count} RU)...")
+    body = {"model_id": model_id, "reservation_units": {"count": ru_count}}
+    resp = mantle_request("POST", "/bedrock/v1/reservations", defaults, body)
+    if not resp:
+        return None
+    res_id = resp.get("reservation_id") or resp.get("id")
+    print(f"  ✓ Reservation created: {res_id}")
+    return res_id
+
+
+def cancel_reservation(reservation_id, defaults):
+    """Cancel an RU reservation."""
+    resp = mantle_request("DELETE", f"/bedrock/v1/reservations/{reservation_id}", defaults)
+    if resp is not None:
+        print(f"  ✓ Reservation cancelled: {reservation_id}")
+
+
+# --- Token ---
+
+def get_or_create_token_secret(defaults):
+    """Generate a Bedrock bearer token and store in Secrets Manager."""
+    from datetime import timedelta
+    from aws_bedrock_token_generator import provide_token
+    import uuid
+
+    region = defaults["region"]
+    token = provide_token(region=region, expiry=timedelta(hours=12))
+    sm = boto3.client("secretsmanager", region_name=region)
+    # Use a stable name so benchmark jobs can always find it
+    secret_name = "bench-byom-token"
+    try:
+        sm.put_secret_value(SecretId=secret_name, SecretString=token)
+        resp = sm.describe_secret(SecretId=secret_name)
+        print(f"  ✓ Token updated: {secret_name}")
+    except sm.exceptions.ResourceNotFoundException:
+        resp = sm.create_secret(Name=secret_name, SecretString=token,
+                                Description="BYOM benchmark token (12h TTL, auto-refreshed)")
+        print(f"  ✓ Token created: {secret_name}")
+    return resp["ARN"], secret_name
+
+
+def cleanup_secret(defaults, secret_name):
+    sm = boto3.client("secretsmanager", region_name=defaults["region"])
+    try:
+        sm.delete_secret(SecretId=secret_name, ForceDeleteWithoutRecovery=True)
+        print(f"  ✓ Deleted secret: {secret_name}")
+    except Exception:
+        pass
+
+
+# --- Benchmarking ---
+
+def run_byom_benchmark(client, job, defaults, secret_arn):
+    """Submit a single benchmark job against BYOM model."""
+    region = defaults["region"]
+    s3_output = defaults["s3_output"].format(region=region)
+    timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
+    s3_job_path = f"{s3_output}/{job['model_key']}/{job['workload_key']}/byom-c{job['concurrency']}/{timestamp}/"
+
+    ts = datetime.now().strftime("%m%d%H%M")
+    job_name = f"{job['id'][:50]}-{ts}".replace("_", "-")
+    config_name = f"byom-{job['model_key']}-{job['workload_key']}-c{job['concurrency']}"[:63].replace("_", "-")
+
+    # BYOM models are served via the Mantle inference endpoint (not bedrock-runtime)
+    bedrock_url = f"https://bedrock-mantle.{region}.api.aws/v1"
+
+    print(f"\n{'─'*60}")
+    print(f"[byom] {job['id']}")
+    print(f"  model={job['model_id']} concurrency={job['concurrency']}")
+    print(f"  in={job['input_tokens']} out={job['output_tokens']}")
+    print(f"{'─'*60}")
+
+    workload_spec = {
+        "benchmark": {"type": "aiperf"},
+        "parameters": {
+            "url": bedrock_url,
+            "model": job["model_id"],
+            "tokenizer": job["tokenizer"],
+            "concurrency": job["concurrency"],
+            "streaming": job["streaming"],
+            "prompt_input_tokens_mean": job["input_tokens"],
+            "output_tokens_mean": job["output_tokens"],
+            "benchmark_duration": job["duration"],
+            "warmup_duration": job["warmup"],
+        },
+        "secrets": {"api_key": secret_arn},
+    }
+
+    # Create workload config
+    try:
+        client.delete_ai_workload_config(AIWorkloadConfigName=config_name)
+    except Exception:
+        pass
+    try:
+        client.create_ai_workload_config(
+            AIWorkloadConfigName=config_name,
+            AIWorkloadConfigs={"WorkloadSpec": {"Inline": json.dumps(workload_spec)}},
+        )
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+    # Create benchmark job
+    try:
+        client.delete_ai_benchmark_job(AIBenchmarkJobName=job_name)
+    except Exception:
+        pass
+    try:
+        client.create_ai_benchmark_job(
+            AIBenchmarkJobName=job_name,
+            AIWorkloadConfigIdentifier=config_name,
+            BenchmarkTarget={"Endpoint": {"Identifier": DIRECT_URL_SENTINEL}},
+            OutputConfig={"S3OutputLocation": s3_job_path},
+            RoleArn=defaults["role_arn"],
+            Tags=[
+                {"Key": "project", "Value": "benchmarking-initiative"},
+                {"Key": "environment", "Value": "byom"},
+                {"Key": "model", "Value": job["model_key"]},
+                {"Key": "workload", "Value": job["workload_key"]},
+                {"Key": "concurrency", "Value": str(job["concurrency"])},
+            ],
+        )
+        print(f"  ✓ Benchmark job submitted: {job_name}")
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+    # Poll
+    print(f"  ⏳ Polling (every 30s, up to 30 min)...")
+    for _ in range(60):
+        try:
+            resp = client.describe_ai_benchmark_job(AIBenchmarkJobName=job_name)
+            status = resp["AIBenchmarkJobStatus"]
+        except Exception:
+            time.sleep(30)
+            continue
+        if status == "Completed":
+            s3_loc = resp["OutputConfig"]["S3OutputLocation"]
+            print(f"  ✓ Completed — {s3_loc}")
+            from athena_writer import write_athena_record
+            model_cfg = models.get(job["model_key"], {})
+            write_athena_record({
+                "job_id": job_name, "environment": "byom",
+                "model_key": job["model_key"], "model_id": job["model_id"],
+                "workload": job["workload_key"], "concurrency": job["concurrency"],
+                "input_tokens": job["input_tokens"], "output_tokens": job["output_tokens"],
+                "streaming": job["streaming"], "duration": job["duration"],
+                "warmup": job["warmup"], "source_region": region,
+                "s3_output": s3_loc, "timestamp": timestamp,
+            }, model_config=model_cfg, defaults_config=defaults, config_source="benchmarks.yaml")
+            return {"success": True, "s3_output": s3_loc}
+        if status in ("Failed", "Stopped"):
+            reason = resp.get("FailureReason", "unknown")
+            print(f"  ✗ {status}: {reason}")
+            return {"success": False, "error": reason}
+        time.sleep(30)
+    return {"success": False, "error": "Timed out after 30 min"}
+
+
+# --- Submit Mode (runs on your laptop) ---
+
+def submit_job(args):
+    """Package and submit a SageMaker Processing Job."""
+    config = load_config(args.config)
+    defaults = config.get("byom_defaults", {})
+    models = config.get("models", {})
+
+    model_key = args.model
+    if not model_key or model_key not in models:
+        print(f"ERROR: --model required. Available: {list(models.keys())}", file=sys.stderr)
+        sys.exit(1)
+
+    region = defaults.get("region", "us-east-1")
+    role = defaults.get("role_arn")
+    job_name = f"bench-byom-{model_key}-{datetime.now().strftime('%m%d-%H%M')}"[:63]
+
+    sm = boto3.client("sagemaker", region_name=region)
+    s3 = boto3.client("s3", region_name=region)
+    account = boto3.client("sts", region_name=region).get_caller_identity()["Account"]
+    bucket = f"sagemaker-benchmark-{region}-{account}"
+
+    # Upload config + script + deps
+    script_dir = os.path.dirname(__file__)
+    config_key = f"processing-configs/{job_name}/benchmarks.yaml"
+    script_key = f"processing-configs/{job_name}/benchmark_bedrock_byom.py"
+    req_key = f"processing-configs/{job_name}/requirements.txt"
+    s3.put_object(Bucket=bucket, Key=config_key, Body=open(args.config).read())
+    s3.put_object(Bucket=bucket, Key=script_key, Body=open(__file__).read())
+    req_path = os.path.join(script_dir, "requirements.txt")
+    if os.path.exists(req_path):
+        s3.put_object(Bucket=bucket, Key=req_key, Body=open(req_path).read())
+    athena_path = os.path.join(script_dir, "athena_writer.py")
+    if os.path.exists(athena_path):
+        s3.put_object(Bucket=bucket, Key=f"processing-configs/{job_name}/athena_writer.py", Body=open(athena_path).read())
+
+    instance_type = defaults.get("processing_instance_type", "ml.m7i.8xlarge")
+    volume_gb = defaults.get("processing_volume_gb", 2000)
+
+    print(f"\n{'='*60}")
+    print(f"Submitting Processing Job: {job_name}")
+    print(f"  Model: {model_key}")
+    print(f"  Region: {region}")
+    print(f"  Instance: {instance_type} ({volume_gb}GB disk)")
+    print(f"{'='*60}\n")
+
+    sm.create_processing_job(
+        ProcessingJobName=job_name,
+        ProcessingResources={
+            "ClusterConfig": {
+                "InstanceCount": 1,
+                "InstanceType": instance_type,
+                "VolumeSizeInGB": volume_gb,
+            }
+        },
+        AppSpecification={
+            "ImageUri": f"763104351884.dkr.ecr.{region}.amazonaws.com/pytorch-training:2.5.1-cpu-py311",
+            "ContainerEntrypoint": ["python3", "/opt/ml/processing/input/script/benchmark_bedrock_byom.py"],
+            "ContainerArguments": ["--model", model_key] + (["--benchmark-only"] if args.benchmark_only else []) + (["--import-only"] if args.import_only else []),
+        },
+        Environment={
+            "SM_PROCESSING_MODE": "byom-benchmark",
+            "MODEL_KEY": model_key,
+        },
+        ProcessingInputs=[
+            {
+                "InputName": "script",
+                "S3Input": {
+                    "S3Uri": f"s3://{bucket}/processing-configs/{job_name}/",
+                    "LocalPath": "/opt/ml/processing/input/script",
+                    "S3DataType": "S3Prefix",
+                    "S3InputMode": "File",
+                },
+            },
+        ],
+        ProcessingOutputConfig={
+            "Outputs": [{
+                "OutputName": "results",
+                "S3Output": {
+                    "S3Uri": f"s3://{bucket}/byom/{model_key}/",
+                    "LocalPath": "/opt/ml/processing/output",
+                    "S3UploadMode": "EndOfJob",
+                },
+            }]
+        },
+        RoleArn=role,
+        StoppingCondition={"MaxRuntimeInSeconds": 432000},  # 5 days
+        NetworkConfig={"EnableNetworkIsolation": False},
+    )
+
+    print(f"  ✓ Job submitted: {job_name}")
+    print(f"  Monitor: aws sagemaker describe-processing-job --processing-job-name {job_name} --region {region}")
+    print(f"  Logs: /aws/sagemaker/ProcessingJobs in CloudWatch ({region})")
+
+
+# --- Execution Mode (runs inside the Processing Job or locally without --submit) ---
+
+def run_pipeline(model_filter=None, workload_filter=None, import_only=False, benchmark_only=False):
+    """Full BYOM pipeline: download → upload → import → reserve → benchmark."""
+    import subprocess
+
+    config = load_config()
+    defaults = config.get("byom_defaults", {})
+    models = config.get("models", {})
+    region = defaults["region"]
+
+    # If inside Processing Job, override model filter from env
+    if ENTRYPOINT_MODE:
+        model_filter = os.environ.get("MODEL_KEY", model_filter)
+
+    jobs = expand_byom_jobs(config, model_filter, workload_filter)
+    unique_models = sorted(set(j["model_key"] for j in jobs))
+    reservations = {}
+
+    if not benchmark_only:
+        for model_key in unique_models:
+            model_cfg = models[model_key]
+            model_id = model_cfg.get("byom", {}).get("model_id", "")
+
+            if not model_id:
+                # Verify weights are staged in S3
+                weights_uri = check_weights_in_s3(model_key, model_cfg, defaults)
+                if not weights_uri:
+                    continue
+                model_cfg["weights_s3_uri"] = weights_uri
+                # Import
+                model_id = import_model(model_key, model_cfg, defaults)
+                if not model_id:
+                    print(f"  ✗ Failed to import {model_key}, skipping")
+                    continue
+                if not poll_import(model_id, defaults):
+                    continue
+                model_cfg.setdefault("byom", {})["model_id"] = model_id
+                print(f"  💡 Add model_id: \"{model_id}\" to models.{model_key}.byom in benchmarks.yaml")
+
+            # Create RU reservation
+            res_id = create_reservation(model_id, defaults)
+            if res_id:
+                reservations[model_key] = res_id
+
+    if import_only:
+        print("\n  ✓ Import complete (--import-only)")
+        return
+
+    # Create reservations for benchmark-only mode (skipped above)
+    if benchmark_only:
+        for model_key in unique_models:
+            model_cfg = models[model_key]
+            model_id = model_cfg.get("byom", {}).get("model_id", "")
+            if model_id:
+                res_id = create_reservation(model_id, defaults)
+                if res_id:
+                    reservations[model_key] = res_id
+
+    # Benchmark
+    print("\nGenerating Bedrock token...")
+    secret_arn, secret_name = get_or_create_token_secret(defaults)
+    client = boto3.client("sagemaker", region_name=region,
+                          config=boto3.session.Config(parameter_validation=False))
+
+    output_dir = Path("/opt/ml/processing/output") if ENTRYPOINT_MODE else RESULTS_DIR / "byom-latest"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    results = []
+    gaps = []
+
+    try:
+        for job in jobs:
+            job["model_id"] = models[job["model_key"]].get("byom", {}).get("model_id", "")
+            if not job["model_id"]:
+                gaps.append({"model": job["model_key"], "job": job["id"], "error": "model not imported"})
+                continue
+
+            result_file = output_dir / f"{job['id']}.json"
+            if result_file.exists():
+                existing = json.loads(result_file.read_text())
+                if existing.get("success"):
+                    print(f"\n  ⏭️  Skipping {job['id']} (completed)")
+                    results.append(existing)
+                    continue
+
+            result = run_byom_benchmark(client, job, defaults, secret_arn)
+            result["id"] = job["id"]
+            results.append(result)
+            result_file.write_text(json.dumps(result, indent=2, default=str))
+            if not result.get("success"):
+                gaps.append({"model": job["model_key"], "job": job["id"], "error": result.get("error", "")})
+    finally:
+        print("\nCancelling RU reservations...")
+        for mk, rid in reservations.items():
+            cancel_reservation(rid, defaults)
+
+    # Secret persists for async benchmark jobs (12h TTL, refreshed each run)
+
+    summary = {
+        "run_id": "byom-latest", "target": "byom",
+        "total": len(results),
+        "completed": sum(1 for r in results if r.get("success")),
+        "failed": sum(1 for r in results if not r.get("success")),
+        "gaps": gaps,
+    }
+    (output_dir / "summary.json").write_text(json.dumps(summary, indent=2, default=str))
+
+    print(f"\n{'═'*60}")
+    print("BYOM BENCHMARK SUMMARY")
+    print(f"{'═'*60}")
+    print(f"Total: {summary['total']} | Completed: {summary['completed']} | Failed: {summary['failed']}")
+    if gaps:
+        print(f"\nGAPS ({len(gaps)}):")
+        for g in gaps:
+            print(f"  ✗ {g['job']}: {g['error'][:100]}")
+
+
+# --- Main ---
+
+def main():
+    # If running inside Processing Job, parse container args and run pipeline
+    if ENTRYPOINT_MODE:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--model", default=None)
+        parser.add_argument("--benchmark-only", action="store_true")
+        parser.add_argument("--import-only", action="store_true")
+        args = parser.parse_args()
+        run_pipeline(model_filter=args.model, import_only=args.import_only, benchmark_only=args.benchmark_only)
+        return
+
+    parser = argparse.ArgumentParser(
+        description="Bedrock BYOM (Bring Your Own Model) — import weights via Mantle API, reserve RUs, benchmark.",
+        epilog="""
+examples:
+  %(prog)s --validate                    Show expanded job matrix without running
+  %(prog)s --submit --model=gpt-oss-120b-byom
+                                         Submit full pipeline as Processing Job (download → import → benchmark)
+  %(prog)s --submit --import-only --model=gpt-oss-120b-byom
+                                         Submit import-only job (no benchmarking)
+  %(prog)s --submit --benchmark-only --model=gpt-oss-120b-byom
+                                         Submit benchmark-only job (model_id must be in config)
+  %(prog)s --model=gpt-oss              Run locally, filter by model substring
+  %(prog)s --import-only --model=kimi   Import only, no benchmark
+  %(prog)s --benchmark-only             Benchmark already-imported models (skips download/import)
+
+config: reads from benchmarks.yaml (models[].byom, workloads, byom_defaults, byom_benchmarks)
+flow:   download weights → upload to S3 → import via Mantle API → create RU reservation → benchmark → cancel RU
+auth:   generates a 12h bearer token, stores in Secrets Manager (auto-cleaned after run)
+cost:   RU reservations billed per minute — auto-cancelled after benchmarking completes
+resume: re-run safely — completed jobs are skipped, weights skip re-upload if already in S3
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("config", nargs="?", default="../benchmarks.yaml", help="Path to benchmarks.yaml config (default: ../benchmarks.yaml)")
+    parser.add_argument("--validate", action="store_true", help="Show expanded job matrix and exit (no AWS calls)")
+    parser.add_argument("--list", action="store_true", help="List all BYOM customized models on Mantle")
+    parser.add_argument("--status", help="Check import status of a specific model ID")
+    parser.add_argument("--import-only", action="store_true", help="Download, upload, and import model only (no benchmark)")
+    parser.add_argument("--benchmark-only", action="store_true", help="Benchmark only — model_id must already be set in config")
+    parser.add_argument("--model", help="Filter by model key substring (e.g. 'gpt-oss', 'kimi')")
+    parser.add_argument("--workload", help="Filter by workload key substring (e.g. 'rag', 'chat')")
+    parser.add_argument("--submit", action="store_true", help="Submit as SageMaker Processing Job (2TB disk, 5-day timeout)")
+    args = parser.parse_args()
+
+    if args.list:
+        config = load_config(args.config)
+        defaults = config.get("byom_defaults", {})
+        print("Listing BYOM customized models...\n")
+        resp = mantle_request("GET", "/bedrock/v1/models/customization", defaults)
+        if resp:
+            models_list = resp if isinstance(resp, list) else resp.get("models", resp.get("data", [resp]))
+            for m in models_list:
+                mid = m.get("model_id", m.get("id", "?"))
+                status = m.get("status", "?")
+                base = m.get("base_model_id", "?")
+                print(f"  {mid}  base={base}  status={status}")
+            print(f"\nTotal: {len(models_list)}")
+        else:
+            print("  No models found or API returned empty response.")
+        return
+
+    if args.status:
+        config = load_config(args.config)
+        defaults = config.get("byom_defaults", {})
+        print(f"Checking status of model: {args.status}\n")
+        resp = mantle_request("GET", f"/bedrock/v1/models/customization/{args.status}", defaults)
+        if resp:
+            print(json.dumps(resp, indent=2))
+        else:
+            print("  Model not found or API error.")
+        return
+
+    if args.submit:
+        submit_job(args)
+        return
+
+    config = load_config(args.config)
+    defaults = config.get("byom_defaults", {})
+    models = config.get("models", {})
+    jobs = expand_byom_jobs(config, args.model, args.workload)
+
+    if args.validate:
+        unique_models = sorted(set(j["model_key"] for j in jobs))
+        print(f"Expanded {len(jobs)} BYOM benchmark job(s)\n")
+        for m in unique_models:
+            mc = models[m]
+            status = "✓ imported" if mc.get("byom", {}).get("model_id") else "○ pending import"
+            print(f"  {status} {m} (base={mc.get('byom', {}).get('base_model_id', '?')})")
+        print(f"\nMantle endpoint: {defaults['mantle_endpoint']}")
+        print(f"Total jobs: {len(jobs)}")
+        return
+
+    # Local execution (same as Processing Job but on your machine)
+    run_pipeline(model_filter=args.model, workload_filter=args.workload, import_only=args.import_only, benchmark_only=args.benchmark_only)
+
+
+if __name__ == "__main__":
+    # Upgrade deps in Processing Job, then re-exec to pick up new packages
+    if os.environ.get("SM_PROCESSING_MODE") and not os.environ.get("_DEPS_INSTALLED"):
+        import subprocess
+        subprocess.run(["pip", "install", "-q", "-r", "/opt/ml/processing/input/script/requirements.txt"])
+        os.environ["_DEPS_INSTALLED"] = "1"
+        os.execv(sys.executable, [sys.executable] + sys.argv)
+    main()

--- a/07-benchmark/autobench/sdk/benchmark_hyperpod.py
+++ b/07-benchmark/autobench/sdk/benchmark_hyperpod.py
@@ -1,0 +1,799 @@
+#!/usr/bin/env python3
+"""
+HyperPod EKS benchmarking via AI Benchmarking direct-URL feature.
+
+Deploys vLLM on a HyperPod cluster's p6-b200 node, exposes via ELB,
+then submits benchmark jobs targeting the ELB URL.
+
+Usage:
+    python sdk/benchmark_hyperpod.py --check
+    python sdk/benchmark_hyperpod.py --validate
+    python sdk/benchmark_hyperpod.py --deploy-only
+    python sdk/benchmark_hyperpod.py
+    python sdk/benchmark_hyperpod.py --model=gemma
+    python sdk/benchmark_hyperpod.py --cleanup
+
+Prerequisites:
+    - kubectl configured for the HyperPod EKS cluster
+    - p6-b200 node available in the cluster (via FTP node group)
+    - Helm (optional, or raw manifests)
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import boto3
+import yaml
+
+RESULTS_DIR = Path("results")
+DIRECT_URL_SENTINEL = "bench-direct-7f2a9c4e1b8d053f6a9e2c7d4b1f8a3e5d0c6b9a4e8f2a1d"
+
+VLLM_K8S_MANIFEST = """
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-{name}
+  namespace: {namespace}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-{name}
+  template:
+    metadata:
+      labels:
+        app: vllm-{name}
+    spec:
+      # Pin to the FTP node via instance type
+      serviceAccountName: vllm-s3-reader
+      nodeSelector:
+        node.kubernetes.io/instance-type: {instance_type}
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: vllm
+          image: {image}
+          args:
+            - "--model"
+            - "{model_id}"
+            - "--tensor-parallel-size"
+            - "{num_gpus}"
+            - "--gpu-memory-utilization"
+            - "{gpu_memory_utilization}"
+            - "--max-model-len"
+            - "{max_model_len}"
+            - "--trust-remote-code"
+            - "--port"
+            - "8000"
+            - "--host"
+            - "0.0.0.0"
+            - "--served-model-name"
+            - "{served_model_name}"
+{extra_args}
+          env:
+            - name: HF_TOKEN
+              value: "{hf_token}"
+{extra_env}
+          ports:
+            - containerPort: 8000
+              name: http
+          resources:
+            limits:
+              nvidia.com/gpu: "{num_gpus}"
+            requests:
+              nvidia.com/gpu: "{num_gpus}"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 300
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 1800
+            periodSeconds: 30
+            failureThreshold: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-{name}
+  namespace: {namespace}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+spec:
+  type: LoadBalancer
+  selector:
+    app: vllm-{name}
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+"""
+
+
+# --- Config ---
+
+def load_config(path="benchmarks.yaml"):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def expand_hyperpod_jobs(config, model_filter=None, workload_filter=None):
+    defaults = config.get("hyperpod_defaults", {})
+    models = config.get("models", {})
+    workloads = config.get("workloads", {})
+    benchmarks = config.get("hyperpod_benchmarks", config.get("sagemaker_benchmarks", []))
+    jobs = []
+
+    for bench in benchmarks:
+        model_key = bench["model"]
+        model = models.get(model_key)
+        if not model:
+            print(f"ERROR: Unknown model '{model_key}'", file=sys.stderr)
+            sys.exit(1)
+        if model_filter and model_filter not in model_key:
+            continue
+        for wl_name in bench["workloads"]:
+            if workload_filter and workload_filter not in wl_name:
+                continue
+            workload = workloads.get(wl_name)
+            if not workload:
+                print(f"ERROR: Unknown workload '{wl_name}'", file=sys.stderr)
+                sys.exit(1)
+            for concurrency in workload["concurrency"]:
+                jobs.append({
+                    "id": f"hp-{model_key}--{wl_name}--c{concurrency}",
+                    "model_key": model_key,
+                    "model_name": model["model_name"],
+                    "num_gpus": model.get("num_gpus", 8),
+                    "workload_key": wl_name,
+                    "concurrency": concurrency,
+                    "input_tokens": workload["input_tokens"],
+                    "output_tokens": workload["output_tokens"],
+                    "streaming": workload.get("streaming", True),
+                    "duration": workload.get("duration", 300),
+                    "warmup": workload.get("warmup", 30),
+                    "dataset": workload.get("dataset"),
+                })
+    return jobs
+
+
+# --- Cluster Configuration ---
+
+def configure_kubectl(defaults):
+    """Auto-configure kubectl for the HyperPod cluster's underlying EKS cluster."""
+    region = defaults.get("region", "us-east-2")
+    eks_cluster = defaults.get("eks_cluster_name")
+
+    if not eks_cluster:
+        # Resolve EKS cluster from HyperPod cluster name
+        hyperpod_name = defaults.get("hyperpod_cluster_name")
+        if not hyperpod_name:
+            print("  ⚠️  No cluster configured — assuming kubectl is already set up")
+            return
+        print(f"  Resolving EKS cluster from HyperPod: {hyperpod_name}")
+        sm = boto3.client("sagemaker", region_name=region)
+        resp = sm.describe_cluster(ClusterName=hyperpod_name)
+        # The EKS cluster ARN is in the orchestrator config
+        eks_arn = resp.get("Orchestrator", {}).get("Eks", {}).get("ClusterArn", "")
+        if not eks_arn:
+            print(f"  ✗ Could not resolve EKS cluster from HyperPod '{hyperpod_name}'")
+            sys.exit(1)
+        eks_cluster = eks_arn.split("/")[-1]
+        print(f"  ✓ Resolved EKS cluster: {eks_cluster}")
+
+    # Update kubeconfig
+    print(f"  Configuring kubectl for {eks_cluster} in {region}...")
+    r = subprocess.run(
+        ["aws", "eks", "update-kubeconfig", "--name", eks_cluster, "--region", region],
+        capture_output=True, text=True
+    )
+    if r.returncode != 0:
+        print(f"  ✗ Failed to configure kubectl: {r.stderr}")
+        sys.exit(1)
+    print(f"  ✓ kubectl configured for {eks_cluster}")
+
+
+# --- Dependency Checks ---
+
+def check_dependencies(defaults):
+    errors = []
+
+    # kubectl
+    try:
+        r = subprocess.run(["kubectl", "cluster-info"], capture_output=True, timeout=10)
+        if r.returncode == 0:
+            print(f"  ✓ kubectl connected to cluster")
+        else:
+            errors.append("kubectl cannot reach cluster. Configure kubeconfig for HyperPod EKS.")
+    except FileNotFoundError:
+        errors.append("kubectl not installed")
+
+    # Check FTP node exists
+    try:
+        # Get instance type from first model in config (strip ml. prefix for K8s label)
+        instance_type = "p6-b200.48xlarge"  # default
+        r = subprocess.run(
+            ["kubectl", "get", "nodes", "-l", f"node.kubernetes.io/instance-type={instance_type}", "-o", "name"],
+            capture_output=True, text=True, timeout=10
+        )
+        nodes = [n for n in r.stdout.strip().split("\n") if n]
+        if nodes:
+            print(f"  ✓ {instance_type} node(s) found: {len(nodes)}")
+        else:
+            errors.append(f"No {instance_type} nodes found in cluster. Check FTP node group.")
+    except Exception as e:
+        errors.append(f"Cannot check nodes: {e}")
+
+    # AWS credentials
+    try:
+        sts = boto3.client("sts", region_name=defaults.get("region", "us-east-2"))
+        identity = sts.get_caller_identity()
+        print(f"  ✓ AWS credentials valid (account: {identity['Account']})")
+    except Exception as e:
+        errors.append(f"AWS credentials invalid: {e}")
+
+    if errors:
+        print(f"\n✗ Dependency check FAILED:")
+        for e in errors:
+            print(f"  ✗ {e}")
+        sys.exit(1)
+    print(f"\n✓ All checks passed.")
+
+
+# --- Deployment (kubectl) ---
+
+def deploy_model_k8s(model_key, model_cfg, defaults):
+    """Deploy vLLM on the p6-b200 node via kubectl."""
+    namespace = defaults.get("namespace", "default")
+    # Ensure namespace exists
+    subprocess.run(["kubectl", "create", "namespace", namespace], capture_output=True)
+    image = defaults.get("vllm_image", "vllm/vllm-openai:v0.20.2")
+    model_id = model_cfg["model_name"]
+    s3_model_uri = model_cfg.get("s3_model_uri", "")
+    num_gpus = str(model_cfg.get("num_gpus", 8))
+    hf_token = os.environ.get("HF_TOKEN", "")
+    name = model_key[:40]
+    vllm_config = defaults.get("vllm_config", {})
+    max_model_len = str(vllm_config.get("max_model_len", "16384"))
+    gpu_memory_utilization = str(vllm_config.get("gpu_memory_utilization", "0.9"))
+    # Per-model vLLM CLI args for HyperPod (EC2 image doesn't have SM_VLLM_* translation)
+    extra_args = model_cfg.get("hyperpod_args", [])
+    # Format extra args as YAML list items for the manifest template
+    extra_args_yaml = "\n".join(f'            - "{arg}"' for arg in extra_args) if extra_args else ""
+
+    # Per-model env vars for HyperPod pod (e.g., VLLM_USE_FLASHINFER_MOE_FP4)
+    hyperpod_env = model_cfg.get("hyperpod_env", {})
+    extra_env_yaml = "\n".join(
+        f'            - name: {k}\n              value: "{v}"' for k, v in hyperpod_env.items()
+    ) if hyperpod_env else ""
+
+    # K8s node label uses the full instance type (including ml. prefix on HyperPod)
+    instance_type = model_cfg.get("instance_type", "ml.p6-b200.48xlarge")
+    # Use S3 URI as model path if set, otherwise HuggingFace ID
+    model_source = s3_model_uri if s3_model_uri else model_id
+    served_model_name=model_id
+
+    print(f"\n{'='*60}")
+    print(f"[deploy-k8s] {model_key}")
+    print(f"  image: {image}")
+    print(f"  model: {model_id}")
+    if s3_model_uri:
+        print(f"  source: {s3_model_uri} (S3)")
+    else:
+        print(f"  source: HuggingFace (direct download)")
+    print(f"  gpus: {num_gpus}")
+    print(f"  namespace: {namespace}")
+    print(f"  served model: {served_model_name}")
+    if extra_args:
+        print(f"  extra vllm args: {extra_args}")
+    print(f"{'='*60}")
+
+    manifest = VLLM_K8S_MANIFEST.format(
+        name=name, namespace=namespace, image=image,
+        model_id=model_source, num_gpus=num_gpus, hf_token=hf_token,
+        max_model_len=max_model_len, gpu_memory_utilization=gpu_memory_utilization,
+        instance_type=instance_type, served_model_name=model_id,
+        extra_args=extra_args_yaml,
+        extra_env=extra_env_yaml,
+    )
+
+    # Delete stale service to force NLB recreation
+    subprocess.run(["kubectl", "delete", "svc", f"vllm-{name}", "-n", namespace, "--ignore-not-found"], capture_output=True)
+    time.sleep(5)
+
+    # Apply manifest
+    r = subprocess.run(["kubectl", "apply", "-f", "-"], input=manifest, text=True, capture_output=True)
+    if r.returncode != 0:
+        return {"success": False, "error": f"kubectl apply failed: {r.stderr}"}
+    print(f"  ✓ Applied deployment + service")
+
+    # Wait for pod ready
+    print(f"  ⏳ Waiting for pod ready (model download + load)...")
+    for _ in range(60):
+        r = subprocess.run(
+            ["kubectl", "get", "pods", "-n", namespace, "-l", f"app=vllm-{name}",
+             "-o", "jsonpath={.items[0].status.conditions[?(@.type=='Ready')].status}"],
+            capture_output=True, text=True
+        )
+        if r.stdout.strip() == "True":
+            print(f"  ✓ Pod ready")
+            break
+        time.sleep(30)
+    else:
+        return {"success": False, "error": "Pod not ready after 30 min"}
+
+    # Get Pod IP directly (benchmark runner is in same VPC)
+    # print(f"  ⏳ Getting pod IP...")
+    # for _ in range(10):
+    #     r = subprocess.run(
+    #         ["kubectl", "get", "pod", "-n", namespace, "-l", f"app=vllm-{name}",
+    #         "-o", "jsonpath={.items[0].status.podIP}"],
+    #         capture_output=True, text=True
+    #     )
+    #     pod_ip = r.stdout.strip()
+    #     if pod_ip:
+    #         url = f"http://{pod_ip}:8080/v1"
+    #         print(f"  ✓ Pod URL: {url}")
+    #         return {"success": True, "url": url, "name": name}
+    #     time.sleep(10)
+    # return {"success": False, "error": "Pod IP not available"}
+
+    # Get ELB URL
+    print(f"  ⏳ Waiting for LoadBalancer URL...")
+    for _ in range(20):
+        r = subprocess.run(
+            ["kubectl", "get", "svc", f"vllm-{name}", "-n", namespace,
+             "-o", "jsonpath={.status.loadBalancer.ingress[0].hostname}"],
+            capture_output=True, text=True
+        )
+        hostname = r.stdout.strip()
+        # if hostname:
+        #     url = f"http://{hostname}/v1"
+        #     print(f"  ✓ ELB URL: {url}")
+        #     return {"success": True, "url": url, "name": name}
+        if hostname:
+              url = f"http://{hostname}/v1"
+              print(f"  ✓ ELB URL: {url}")
+              # Wait for NLB target to be healthy
+              print(f"  ⏳ Waiting for NLB target registration...")
+              for _ in range(30):
+                  r = subprocess.run(
+                      ["kubectl", "get", "endpoints", f"vllm-{name}", "-n", namespace,
+                       "-o", "jsonpath={.subsets[0].addresses[0].ip}"],
+                      capture_output=True, text=True
+                  )
+                  if r.stdout.strip():
+                      print(f"  ✓ Endpoint registered: {r.stdout.strip()}")
+                      break
+                  time.sleep(10)
+              time.sleep(30)  # Extra wait for NLB health check to pass
+              return {"success": True, "url": url, "name": name}
+        time.sleep(15)
+    return {"success": False, "error": "LoadBalancer hostname not assigned"}
+
+
+def cleanup_model_k8s(model_key, defaults):
+    namespace = defaults.get("namespace", "default")
+    name = model_key[:40]
+    print(f"\n[cleanup-k8s] {model_key}")
+    subprocess.run(["kubectl", "delete", "deployment", f"vllm-{name}", "-n", namespace, "--ignore-not-found"], capture_output=True)
+    subprocess.run(["kubectl", "delete", "svc", f"vllm-{name}", "-n", namespace, "--ignore-not-found"], capture_output=True)
+    # Wait for pod to fully terminate before returning
+    print(f"  ⏳ Waiting for pod termination...")
+    for _ in range(30):
+        r = subprocess.run(
+            ["kubectl", "get", "pods", "-n", namespace, "-l", f"app=vllm-{name}", "-o", "name"],
+            capture_output=True, text=True
+        )
+        if not r.stdout.strip():
+            break
+        time.sleep(10)
+    print(f"  ✓ Cleanup complete")
+
+
+# --- Benchmarking (direct-URL via AIPerf) ---
+
+def get_sagemaker_client(defaults):
+    return boto3.client("sagemaker", region_name=defaults.get("region", "us-east-2"),
+                          config=boto3.session.Config(parameter_validation=False))
+
+
+def run_hyperpod_benchmark(client, job, elb_url, defaults, models=None):
+    """Submit benchmark job targeting the HyperPod ELB URL.
+    Uses the 'url' parameter in the workload spec + NetworkConfig for VPC access.
+    """
+    role = defaults["role_arn"]
+    s3_output = defaults["s3_output"].format(region=defaults.get("region", "us-east-2"))
+
+    # Hierarchical path: {env}/{model}/{workload}/{instance}/{timestamp}/
+    timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
+    s3_job_path = f"{s3_output}/{job['model_key']}/{job['workload_key']}/p6-b200-c{job['concurrency']}/{timestamp}/"
+
+    ts = datetime.now().strftime("%m%d%H%M")
+    job_name = f"{job['id'][:50]}-{ts}".replace("_", "-")
+    config_name = f"hp-{job['model_key']}-{job['workload_key']}-c{job['concurrency']}"[:63].replace("_", "-")
+
+    print(f"\n{'─'*60}")
+    print(f"[benchmark] {job['id']}")
+    print(f"  target: {elb_url}")
+    print(f"  concurrency={job['concurrency']} in={job['input_tokens']} out={job['output_tokens']}")
+    print(f"{'─'*60}")
+
+    workload_spec = {
+        "benchmark": {"type": "aiperf"},
+        "parameters": {
+            "url": elb_url,
+            "model": job["model_name"],
+            "tokenizer": job["model_name"],
+            "concurrency": job["concurrency"],
+            "streaming": job["streaming"],
+            "prompt_input_tokens_mean": job["input_tokens"],
+            "output_tokens_mean": job["output_tokens"],
+            "benchmark_duration": job["duration"],
+            "warmup_duration": job["warmup"],
+        },
+        "tooling": {"api_standard": "openai"},
+    }
+
+    # Create workload config
+    try:
+        client.delete_ai_workload_config(AIWorkloadConfigName=config_name)
+    except Exception:
+        pass
+    try:
+        client.create_ai_workload_config(
+            AIWorkloadConfigName=config_name,
+            AIWorkloadConfigs={"WorkloadSpec": {"Inline": json.dumps(workload_spec)}},
+        )
+    except Exception as e:
+        print(f"  ✗ {e}")
+        return {"success": False, "error": str(e)}
+
+    # Submit job with direct-URL sentinel (service routes to url in workload spec)
+    try:
+        client.delete_ai_benchmark_job(AIBenchmarkJobName=job_name)
+    except Exception:
+        pass
+    try:
+        create_kwargs = {
+            "AIBenchmarkJobName": job_name,
+            "AIWorkloadConfigIdentifier": config_name,
+            "BenchmarkTarget": {"Endpoint": {"Identifier": DIRECT_URL_SENTINEL}},
+            "OutputConfig": {"S3OutputLocation": s3_job_path},
+            "RoleArn": role,
+            "Tags": [
+                {"Key": "project", "Value": "benchmarking-initiative"},
+                {"Key": "environment", "Value": "hyperpod"},
+                {"Key": "model", "Value": job["model_key"]},
+                {"Key": "workload", "Value": job["workload_key"]},
+                {"Key": "concurrency", "Value": str(job["concurrency"])},
+                {"Key": "source-region", "Value": defaults.get("region", "")},
+            ],
+        }
+        # Add NetworkConfig if VPC settings provided (for ELB access)
+        vpc = defaults.get("vpc_config")
+        if vpc:
+            create_kwargs["NetworkConfig"] = {"VpcConfig": vpc}
+        client.create_ai_benchmark_job(**create_kwargs)
+        print(f"  ✓ Created benchmark job: {job_name}")
+    except Exception as e:
+        print(f"  ✗ {e}")
+        return {"success": False, "error": str(e)}
+
+    # Poll
+    for _ in range(60):
+        try:
+            resp = client.describe_ai_benchmark_job(AIBenchmarkJobName=job_name)
+            status = resp["AIBenchmarkJobStatus"]
+        except Exception:
+            time.sleep(30)
+            continue
+        if status == "Completed":
+            print(f"  ✓ Completed")
+            s3_loc = resp["OutputConfig"]["S3OutputLocation"]
+            from athena_writer import write_athena_record
+            model_cfg = (models or {}).get(job["model_key"], {})
+            write_athena_record({
+                "job_id": job_name,
+                "environment": "hyperpod",
+                "model_key": job["model_key"],
+                "model_name": job["model_name"],
+                "workload": job["workload_key"],
+                "concurrency": job["concurrency"],
+                "input_tokens": job["input_tokens"],
+                "output_tokens": job["output_tokens"],
+                "streaming": job["streaming"],
+                "duration": job["duration"],
+                "warmup": job["warmup"],
+                "instance_type": model_cfg.get("instance_type", defaults.get("instance_type", "")),
+                "num_gpus": job.get("num_gpus", model_cfg.get("num_gpus", 8)),
+                "dataset": job.get("dataset"),
+                "source_region": defaults.get("region", ""),
+                "s3_output": s3_loc,
+                "timestamp": timestamp,
+            }, model_config=model_cfg, defaults_config=defaults, config_source="benchmarks.yaml")
+            return {"success": True, "status": "completed", "s3_output": s3_loc}
+        if status in ("Failed", "Stopped"):
+            reason = resp.get("FailureReason", "unknown")
+            print(f"  ✗ {status}: {reason}")
+            return {"success": False, "error": reason}
+        time.sleep(30)
+    return {"success": False, "error": "Timed out"}
+
+
+# --- Main ---
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="HyperPod EKS benchmarking — deploys vLLM on EKS, exposes via NLB, benchmarks via direct-URL.",
+        epilog="""
+examples:
+  %(prog)s --validate                    Show expanded job matrix without running
+  %(prog)s --check                       Verify kubectl, nodes, and credentials
+  %(prog)s                               Deploy + benchmark all models
+  %(prog)s --model=gemma                 Run only models matching 'gemma'
+  %(prog)s --workload=rag               Run only workloads matching 'rag'
+  %(prog)s --deploy-only                 Deploy vLLM pods + NLB, skip benchmarking
+  %(prog)s --benchmark-only              Benchmark existing pods (skip deploy)
+  %(prog)s --cleanup                     Delete pods and services
+  %(prog)s --submit                      Submit as unattended Processing Job
+
+config: reads from benchmarks.yaml (models, workloads, hyperpod_defaults, hyperpod_benchmarks)
+flow:   auto-configures kubectl → deploys vLLM pod → waits for readiness → creates NLB → benchmarks
+note:   single p6-b200 node — models are deployed sequentially with cleanup between them
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("config", nargs="?", default="../benchmarks.yaml", help="Path to benchmarks.yaml config (default: ../benchmarks.yaml)")
+    parser.add_argument("--check", action="store_true", help="Verify kubectl access, node availability, and credentials")
+    parser.add_argument("--validate", action="store_true", help="Show expanded job matrix and exit (no AWS calls)")
+    parser.add_argument("--model", help="Filter by model key substring (e.g. 'gemma', 'qwen3')")
+    parser.add_argument("--workload", help="Filter by workload key substring (e.g. 'rag', 'chat')")
+    parser.add_argument("--deploy-only", action="store_true", help="Deploy vLLM pods and NLB only, skip benchmarking")
+    parser.add_argument("--benchmark-only", action="store_true", help="Benchmark existing pods (skip deploy, use existing ELB)")
+    parser.add_argument("--cleanup", action="store_true", help="Delete all deployed pods and services")
+    parser.add_argument("--submit", action="store_true", help="Submit as a remote SageMaker Processing Job")
+    args = parser.parse_args()
+
+    if args.submit:
+        # HyperPod needs VPC access + kubectl — use a wrapper entrypoint
+        from benchmark import submit_processing_job
+
+        # Override the entrypoint to install kubectl first
+        config = load_config(args.config)
+        defaults = config.get("hyperpod_defaults", {})
+        region = defaults.get("region", "us-east-2")
+        role = defaults.get("role_arn")
+        if not role:
+            raise ValueError("'role_arn' must be set in hyperpod_defaults")
+        s3_output = defaults.get("s3_output", "").format(region=region)
+        bucket = s3_output.replace("s3://", "").split("/")[0] if s3_output else f"sagemaker-benchmark-{region}-{boto3.client('sts', region_name=region).get_caller_identity()['Account']}"
+        job_name = f"bench-hp-{datetime.now().strftime('%m%d-%H%M')}"[:63]
+
+        sm = boto3.client("sagemaker", region_name=region)
+        s3 = boto3.client("s3", region_name="us-east-2")
+
+        # Upload script + config + deps
+        script_dir = os.path.dirname(__file__)
+        s3.put_object(Bucket=bucket, Key=f"processing-configs/{job_name}/script.py", Body=open(__file__).read())
+        s3.put_object(Bucket=bucket, Key=f"processing-configs/{job_name}/benchmarks.yaml", Body=open(args.config).read())
+        req_path = os.path.join(script_dir, "requirements.txt")
+        if os.path.exists(req_path):
+            s3.put_object(Bucket=bucket, Key=f"processing-configs/{job_name}/requirements.txt", Body=open(req_path).read())
+        athena_path = os.path.join(script_dir, "athena_writer.py")
+        if os.path.exists(athena_path):
+            s3.put_object(Bucket=bucket, Key=f"processing-configs/{job_name}/athena_writer.py", Body=open(athena_path).read())
+        # Bootstrap script — installs kubectl + deps, then runs the main script
+        bootstrap = (
+            "#!/bin/bash\nset -e\n"
+            "curl -sLO https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl\n"
+            "chmod +x kubectl && mv kubectl /usr/local/bin/\n"
+            "pip install -q -r /opt/ml/processing/input/script/requirements.txt\n"
+            "pip install -q --upgrade awscli\n"
+            "exec python3 /opt/ml/processing/input/script/script.py "
+            "/opt/ml/processing/input/script/benchmarks.yaml \"$@\"\n"
+        )
+        s3.put_object(Bucket=bucket, Key=f"processing-configs/{job_name}/bootstrap.sh", Body=bootstrap)
+
+        container_args = []
+        if args.model:
+            container_args += ["--model", args.model]
+        if args.workload:
+            container_args += ["--workload", args.workload]
+
+        # VPC config for EKS access
+        vpc_config = defaults.get("vpc_config", {})
+
+        print(f"\n{'='*60}")
+        print(f"Submitting HyperPod Processing Job: {job_name}")
+        print(f"  Region: {region}")
+        print(f"  VPC: {'configured' if vpc_config else 'NOT SET — may not reach EKS'}")
+        print(f"{'='*60}\n")
+
+        create_kwargs = {
+            "ProcessingJobName": job_name,
+            "ProcessingResources": {
+                "ClusterConfig": {
+                    "InstanceCount": 1,
+                    "InstanceType": "ml.m7i.4xlarge",
+                    "VolumeSizeInGB": 50,
+                }
+            },
+            "AppSpecification": {
+                "ImageUri": f"763104351884.dkr.ecr.{region}.amazonaws.com/pytorch-training:2.5.1-cpu-py311",
+                "ContainerEntrypoint": ["/bin/bash", "/opt/ml/processing/input/script/bootstrap.sh"],
+                **({"ContainerArguments": container_args} if container_args else {}),
+            },
+            "ProcessingInputs": [
+                {
+                    "InputName": "script",
+                    "S3Input": {
+                        "S3Uri": f"s3://{bucket}/processing-configs/{job_name}/",
+                        "LocalPath": "/opt/ml/processing/input/script",
+                        "S3DataType": "S3Prefix",
+                        "S3InputMode": "File",
+                    },
+                },
+            ],
+            "ProcessingOutputConfig": {
+                "Outputs": [{
+                    "OutputName": "results",
+                    "S3Output": {
+                        "S3Uri": f"s3://{bucket}/processing-results/{job_name}/",
+                        "LocalPath": "/opt/ml/processing/output",
+                        "S3UploadMode": "EndOfJob",
+                    },
+                }]
+            },
+            "RoleArn": role,
+            "StoppingCondition": {"MaxRuntimeInSeconds": 432000},
+            "NetworkConfig": {"EnableNetworkIsolation": False},
+        }
+
+        # # Add VPC config if provided (required for EKS access)
+        # if vpc_config:
+        #     create_kwargs["NetworkConfig"]["VpcConfig"] = vpc_config
+
+        sm.create_processing_job(**create_kwargs)
+        print(f"  ✓ Job submitted: {job_name}")
+        print(f"  Monitor: aws sagemaker describe-processing-job --processing-job-name {job_name} --region {region}")
+        return
+
+    config = load_config(args.config)
+    defaults = config.get("hyperpod_defaults", {})
+    if not defaults:
+        print("ERROR: No 'hyperpod_defaults' section in config", file=sys.stderr)
+        sys.exit(1)
+
+    if args.check:
+        configure_kubectl(defaults)
+        check_dependencies(defaults)
+        return
+
+    jobs = expand_hyperpod_jobs(config, args.model, args.workload)
+
+    if args.validate:
+        models = sorted(set(j["model_key"] for j in jobs))
+        workloads = sorted(set(j["workload_key"] for j in jobs))
+        print(f"Expanded {len(jobs)} HyperPod benchmark job(s)\n")
+        print(f"Models ({len(models)}):")
+        for m in models:
+            mc = config["models"][m]
+            print(f"  ✓ {m} ({mc['model_name']}, {mc.get('num_gpus',8)} GPUs)")
+        print(f"\nWorkloads ({len(workloads)}):")
+        for w in workloads:
+            wl = config["workloads"][w]
+            print(f"  ✓ {w}: in={wl['input_tokens']} out={wl['output_tokens']} c=[{','.join(map(str, wl['concurrency']))}]")
+        print(f"\nTotal jobs: {len(jobs)}")
+        return
+
+    # Configure kubectl for the cluster
+    configure_kubectl(defaults)
+
+    # Ensure S3 output bucket exists
+    s3_output = defaults.get("s3_output", "").format(region=defaults.get("region", "us-east-2"))
+    if s3_output:
+        bucket = s3_output.replace("s3://", "").split("/")[0]
+        region = defaults.get("region", "us-east-2")
+        s3 = boto3.client("s3", region_name=region)
+        try:
+            s3.head_bucket(Bucket=bucket)
+        except Exception:
+            try:
+                s3.create_bucket(Bucket=bucket, CreateBucketConfiguration={"LocationConstraint": region})
+                print(f"  ✓ Created S3 bucket: {bucket}")
+            except Exception:
+                pass
+
+    if args.cleanup:
+        models = sorted(set(j["model_key"] for j in jobs))
+        for m in models:
+            cleanup_model_k8s(m, defaults)
+        return
+
+    # Group by model
+    by_model = {}
+    for j in jobs:
+        by_model.setdefault(j["model_key"], []).append(j)
+
+    run_dir = RESULTS_DIR / "hyperpod-latest"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    results = []
+    client = get_sagemaker_client(defaults)
+
+    for model_key, model_jobs in by_model.items():
+        model_cfg = config["models"][model_key]
+
+        # Deploy
+        if not args.benchmark_only:
+            deploy_result = deploy_model_k8s(model_key, model_cfg, defaults)
+            if not deploy_result["success"]:
+                print(f"  ✗ Deploy failed: {deploy_result['error']}")
+                for j in model_jobs:
+                    results.append({"id": j["id"], "success": False, "error": deploy_result["error"]})
+                continue
+            elb_url = deploy_result["url"]
+        else:
+            # Get existing ELB URL
+            namespace = defaults.get("namespace", "default")
+            name = model_key[:40]
+            r = subprocess.run(
+                ["kubectl", "get", "svc", f"vllm-{name}", "-n", namespace,
+                 "-o", "jsonpath={.status.loadBalancer.ingress[0].hostname}"],
+                capture_output=True, text=True
+            )
+            elb_url = f"http://{r.stdout.strip()}/v1"
+            print(f"  Using existing ELB: {elb_url}")
+
+        if args.deploy_only:
+            continue
+
+        # Benchmark
+        for job in model_jobs:
+            result_file = run_dir / f"{job['id']}.json"
+            if result_file.exists():
+                existing = json.loads(result_file.read_text())
+                if existing.get("success"):
+                    print(f"\n  ⏭️  Skipping {job['id']} (already completed)")
+                    results.append(existing)
+                    continue
+
+            result = run_hyperpod_benchmark(client, job, elb_url, defaults, models=config.get("models", {}))
+            result["id"] = job["id"]
+            result["model_key"] = job["model_key"]
+            results.append(result)
+            (run_dir / f"{job['id']}.json").write_text(json.dumps(result, indent=2, default=str))
+
+        # Cleanup between models (single node)
+        if defaults.get("cleanup", True) and not args.benchmark_only:
+            cleanup_model_k8s(model_key, defaults)
+            time.sleep(30)
+
+    # Summary
+    summary = {"total": len(results), "completed": sum(1 for r in results if r.get("success")),
+               "failed": sum(1 for r in results if not r.get("success"))}
+    (run_dir / "summary.json").write_text(json.dumps(summary, indent=2, default=str))
+    print(f"\n{'═'*60}")
+    print(f"HYPERPOD BENCHMARK SUMMARY")
+    print(f"{'═'*60}")
+    print(f"Total: {summary['total']} | Completed: {summary['completed']} | Failed: {summary['failed']}")
+    print(f"Results: {run_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/07-benchmark/autobench/sdk/download_models.py
+++ b/07-benchmark/autobench/sdk/download_models.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""
+Model weight downloader — stages HuggingFace models to S3 for fast loading.
+
+Downloads model weights from HuggingFace and uploads to S3 in the target region.
+Run this before benchmarking to avoid timeout issues with large models (100B+).
+
+Usage:
+    python download_models.py --region us-east-2                    Download all models to us-east-2
+    python download_models.py --region us-west-2 --model=kimi       Download only kimi to us-west-2
+    python download_models.py --validate                            Show what would be downloaded
+    python download_models.py --submit --region us-east-2           Submit as Processing Job (2TB disk)
+    python download_models.py --submit --region us-east-2 --model=kimi
+
+output: s3://sagemaker-benchmark-{region}-{account}/models/{model_key}/
+note:   skips models already present in S3 (checks for config.json)
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import boto3
+import yaml
+
+ENTRYPOINT_MODE = os.environ.get("SM_PROCESSING_MODE") == "model-download"
+
+
+def load_config(path="../benchmarks.yaml"):
+    if ENTRYPOINT_MODE:
+        path = "/opt/ml/processing/input/config/benchmarks.yaml"
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def get_account():
+    return boto3.client("sts", region_name="us-east-2").get_caller_identity()["Account"]
+
+
+def check_s3_exists(bucket, prefix, region):
+    """Check if model already exists in S3."""
+    s3 = boto3.client("s3", region_name=region)
+    try:
+        s3.head_object(Bucket=bucket, Key=f"{prefix}config.json")
+        return True
+    except Exception:
+        return False
+
+
+def ensure_bucket(bucket, region):
+    s3 = boto3.client("s3", region_name=region)
+    try:
+        s3.head_bucket(Bucket=bucket)
+    except Exception:
+        try:
+            if region == "us-east-1":
+                s3.create_bucket(Bucket=bucket)
+            else:
+                s3.create_bucket(Bucket=bucket, CreateBucketConfiguration={"LocationConstraint": region})
+            print(f"  ✓ Created bucket: {bucket}")
+        except Exception:
+            pass
+
+
+def download_and_upload(model_key, model_name, region, account, prefix_base="models"):
+    """Download from HuggingFace and upload to S3."""
+    bucket = f"sagemaker-benchmark-{region}-{account}"
+    prefix = f"{prefix_base}/{model_key}/"
+
+    # Skip if already present
+    if check_s3_exists(bucket, prefix, region):
+        print(f"  ⏭️  {model_key} already in s3://{bucket}/{prefix}")
+        return f"s3://{bucket}/{prefix}"
+
+    ensure_bucket(bucket, region)
+
+    # Download
+    local_dir = Path(f"/tmp/models/{model_key}")
+    local_dir.mkdir(parents=True, exist_ok=True)
+    print(f"  ⬇️  Downloading {model_name}...")
+    subprocess.run(["pip", "install", "-q", "huggingface_hub[cli]"], check=True, capture_output=True)
+    subprocess.run(["huggingface-cli", "download", model_name, "--local-dir", str(local_dir)], check=True)
+    print(f"  ✓ Downloaded to {local_dir}")
+
+    # Upload
+    s3_uri = f"s3://{bucket}/{prefix}"
+    print(f"  ⬆️  Uploading to {s3_uri}...")
+    subprocess.run(["aws", "s3", "sync", str(local_dir), s3_uri, "--region", region], check=True)
+    print(f"  ✓ Uploaded to {s3_uri}")
+    return s3_uri
+
+
+def submit_job(args):
+    """Submit as a SageMaker Processing Job."""
+    config = load_config(args.config)
+    defaults = config.get("sagemaker_defaults", {})
+    models = config.get("models", {})
+    region = args.region
+    role = defaults.get("role_arn")
+    if not role:
+        raise ValueError("'role_arn' must be set in sagemaker_defaults")
+    account = get_account()
+    bucket = f"sagemaker-benchmark-{region}-{account}"
+
+    model_suffix = f"-{args.model}" if args.model else ""
+    job_name = f"dl{model_suffix}-{region}-{datetime.now().strftime('%m%d-%H%M%S')}"[:63]
+
+    # Upload config + script
+    s3 = boto3.client("s3", region_name=region)
+    ensure_bucket(bucket, region)
+    config_key = f"processing-configs/{job_name}/benchmarks.yaml"
+    script_key = f"processing-configs/{job_name}/download_models.py"
+    s3.put_object(Bucket=bucket, Key=config_key, Body=open(args.config).read())
+    s3.put_object(Bucket=bucket, Key=script_key, Body=open(__file__).read())
+
+    container_args = ["--region", region]
+    if args.model:
+        container_args += ["--model", args.model]
+
+    sm = boto3.client("sagemaker", region_name=region)
+
+    print(f"\n{'='*60}")
+    print(f"Submitting download job: {job_name}")
+    print(f"  Region: {region}")
+    print(f"  Models: {args.model or 'all'}")
+    print(f"  Instance: ml.m7i.8xlarge (2TB disk)")
+    print(f"{'='*60}\n")
+
+    sm.create_processing_job(
+        ProcessingJobName=job_name,
+        ProcessingResources={
+            "ClusterConfig": {
+                "InstanceCount": 1,
+                "InstanceType": "ml.m7i.8xlarge",
+                "VolumeSizeInGB": 2000,
+            }
+        },
+        AppSpecification={
+            "ImageUri": f"763104351884.dkr.ecr.{region}.amazonaws.com/pytorch-training:2.5.1-cpu-py311",
+            "ContainerEntrypoint": ["python3", "/opt/ml/processing/input/script/download_models.py"],
+            "ContainerArguments": container_args,
+        },
+        Environment={"SM_PROCESSING_MODE": "model-download"},
+        ProcessingInputs=[
+            {
+                "InputName": "config",
+                "S3Input": {
+                    "S3Uri": f"s3://{bucket}/{config_key}",
+                    "LocalPath": "/opt/ml/processing/input/config",
+                    "S3DataType": "S3Prefix",
+                    "S3InputMode": "File",
+                },
+            },
+            {
+                "InputName": "script",
+                "S3Input": {
+                    "S3Uri": f"s3://{bucket}/{script_key}",
+                    "LocalPath": "/opt/ml/processing/input/script",
+                    "S3DataType": "S3Prefix",
+                    "S3InputMode": "File",
+                },
+            },
+        ],
+        ProcessingOutputConfig={
+            "Outputs": [{
+                "OutputName": "dummy",
+                "S3Output": {
+                    "S3Uri": f"s3://{bucket}/processing-configs/{job_name}/output/",
+                    "LocalPath": "/opt/ml/processing/output",
+                    "S3UploadMode": "EndOfJob",
+                },
+            }]
+        },
+        RoleArn=role,
+        StoppingCondition={"MaxRuntimeInSeconds": 432000},
+        NetworkConfig={"EnableNetworkIsolation": False},
+    )
+
+    print(f"  ✓ Job submitted: {job_name}")
+    print(f"  Monitor: aws sagemaker describe-processing-job --processing-job-name {job_name} --region {region}")
+
+
+def run_downloads(region, model_filter=None, target="smai", config_path="../benchmarks.yaml"):
+    """Download all (or filtered) models to S3."""
+    config = load_config(config_path)
+    account = get_account()
+    prefix_base = "models"
+
+    # All models come from the models section
+    targets = []
+    for key, model in sorted(config.get("models", {}).items()):
+        if model_filter and model_filter not in key:
+            continue
+        targets.append((key, model["model_name"]))
+
+    print(f"\nDownloading {len(targets)} model(s) to region: {region} (target: {target})")
+    print(f"Destination: s3://sagemaker-benchmark-{region}-{account}/{prefix_base}/\n")
+
+    results = []
+    for model_key, model_name in targets:
+        print(f"\n{'─'*60}")
+        print(f"[{model_key}] {model_name}")
+        print(f"{'─'*60}")
+        try:
+            uri = download_and_upload(model_key, model_name, region, account, prefix_base)
+            results.append({"model": model_key, "s3_uri": uri, "success": True})
+        except Exception as e:
+            print(f"  ✗ Failed: {e}")
+            results.append({"model": model_key, "error": str(e), "success": False})
+
+    # Summary
+    print(f"\n{'═'*60}")
+    print("DOWNLOAD SUMMARY")
+    print(f"{'═'*60}")
+    ok = sum(1 for r in results if r["success"])
+    print(f"Total: {len(results)} | Success: {ok} | Failed: {len(results) - ok}")
+    if target == "byom":
+        print(f"\nUpdate benchmarks.yaml byom_models weights_s3_uri fields:")
+    else:
+        print(f"\nUpdate benchmarks.yaml models s3_model_uri fields:")
+    for r in results:
+        if r["success"]:
+            print(f"  {r['model']}: \"{r['s3_uri']}\"")
+
+
+def main():
+    if ENTRYPOINT_MODE:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--region", required=True)
+        parser.add_argument("--model", default=None)
+        args = parser.parse_args()
+        subprocess.run(["pip", "install", "-q", "huggingface_hub[cli]", "pyyaml"], check=True, capture_output=True)
+        run_downloads(args.region, args.model)
+        return
+
+    parser = argparse.ArgumentParser(
+        description="Download model weights from HuggingFace and stage in S3 for fast loading.",
+        epilog="""
+examples:
+  %(prog)s --region us-east-2                         Download all models to us-east-2
+  %(prog)s --region us-west-2 --model=kimi            Download only kimi models
+  %(prog)s --validate --region us-east-2              Show what would be downloaded
+  %(prog)s --submit --region us-east-2                Submit as Processing Job (2TB disk)
+  %(prog)s --submit --region us-east-2 --model=kimi   Submit single model download
+
+output: s3://sagemaker-benchmark-{region}-{account}/models/{model_key}/
+note:   after download, update s3_model_uri in benchmarks.yaml for each model
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("config", nargs="?", default="../benchmarks.yaml")
+    parser.add_argument("--region", required=True, help="Target S3 region (should match FTP/cluster region)")
+    parser.add_argument("--model", help="Filter by model key substring")
+    parser.add_argument("--validate", action="store_true", help="Show what would be downloaded (no action)")
+    parser.add_argument("--submit", action="store_true", help="Submit as Processing Job")
+    args = parser.parse_args()
+
+    if args.submit:
+        submit_job(args)
+        return
+
+    config = load_config(args.config)
+    models = config.get("models", {})
+    account = get_account()
+    bucket = f"sagemaker-benchmark-{args.region}-{account}"
+
+    if args.validate:
+        print(f"Models to download → s3://{bucket}/models/\n")
+        for key, model in sorted(models.items()):
+            if args.model and args.model not in key:
+                continue
+            existing = check_s3_exists(bucket, f"models/{key}/", args.region)
+            status = "✓ in S3" if existing else "○ pending"
+            print(f"  {status}  {key} ({model['model_name']})")
+        return
+
+    run_downloads(args.region, args.model, config_path=args.config)
+
+
+if __name__ == "__main__":
+    main()

--- a/07-benchmark/autobench/sdk/requirements.txt
+++ b/07-benchmark/autobench/sdk/requirements.txt
@@ -1,0 +1,9 @@
+aws-bedrock-token-generator==1.1.0
+boto3==1.43.10
+botocore==1.43.10
+jmespath==1.1.0
+python-dateutil==2.9.0.post0
+pyyaml==6.0.3
+s3transfer==0.17.0
+six==1.17.0
+urllib3==2.7.0


### PR DESCRIPTION
# Add AutoBench, LLM Inference Benchmarking Framework

## Summary

Config-driven benchmarking framework for evaluating LLM inference performance across three AWS execution paths: **SageMaker Managed Inference**, **HyperPod EKS**, and **Bedrock BYOM**. A single YAML configuration drives all execution paths — no code changes needed to add models or workloads.

## What's Included

### Core Framework (`sdk/`)
- **`benchmark.py`** — SageMaker Managed Inference path (deploy endpoint → benchmark → cleanup)
- **`benchmark_hyperpod.py`** — HyperPod EKS path (deploy vLLM pod via kubectl → NLB → benchmark)
- **`benchmark_bedrock_byom.py`** — Bedrock BYOM path (Mantle API import → RU reservation → benchmark)
- **`download_models.py`** — Stage model weights from HuggingFace to S3 (shared by all paths)
- **`athena_writer.py`** — Centralized results pipeline (enriched, self-describing Athena records)
- **`backfill.py`** — Re-process historical results with updated schema
- **`athena_ddl.sql`** — Athena table DDL with full expanded schema

### Infrastructure (`infra/`)
- **`hyperpod-cluster-bootstrap.yaml`** — CloudFormation template for HyperPod EKS cluster with pre-configured networking (VPC, subnets, security groups, NLB subnet tags, IAM roles, LB Controller setup)

### Configuration
- **`benchmarks.yaml.example`** — Full-featured template showing all configuration options across all three paths

## Architecture

```
benchmarks.yaml (single source of truth)
       │
       ├── sdk/download_models.py         → Stage weights from HuggingFace to S3
       ├── sdk/benchmark.py               → SageMaker Managed Inference
       ├── sdk/benchmark_hyperpod.py      → HyperPod EKS (kubectl + NLB)
       └── sdk/benchmark_bedrock_byom.py  → Bedrock BYOM (Mantle API)
                    │
                    └── athena_writer.py   → Enriched results → Athena → QuickSight
```

## Key Features

- **Single config** — One YAML defines models, workloads, and benchmark matrices for all paths
- **Unified model definitions** — Models defined once; each path reads its own sub-key (`env` for SMAI, `hyperpod_args` for HP, `byom` for BYOM)
- **Self-describing results** — Every Athena row includes serving context (vLLM version, instance type, quantization, dataset) for tranche-independent comparison
- **Deterministic deduplication** — Re-runs overwrite previous results at the same S3 key (no duplicates)
- **Resume-safe** — Completed jobs are skipped automatically on re-run
- **Set-and-forget** — `--submit` runs as a SageMaker Processing Job (5-day timeout, no credential expiry)
- **31 metrics per run** — Expanded AIPerf extraction including TTFT, ITL, E2E latency, prefill throughput, error rate, sequence lengths, and full raw JSON blob

## Workload Profiles

| Workload | Input | Output | Concurrency | Use Case |
|----------|:-----:|:------:|:-----------:|----------|
| `multi_turn_chat` | 500 | 500 | 1–64 | Copilots, assistants |
| `rag_document_qa` | 5,000 | 500 | 1–32 | Knowledge bases, search |
| `agent_tool_calling` | 1,000 | 200 | 1–64 | Coding agents, automation |
| `long_context_scaling` | 10,000 | 500 | 1–16 | Prefill stress test |
| `production_traffic_mix` | 1,000 | 1,000 | 1–64 | Aggregate real traffic |
| `shared_system_prompt` | 3,000 | 500 | 4–16 | Prefix caching |

## Quick Start

```bash
cd sdk
uv venv && source .venv/bin/activate
uv pip install -r requirements.txt

# Copy and configure
cp benchmarks.yaml.example benchmarks.yaml
# Edit benchmarks.yaml with your account, region, models, etc.

# Stage model weights
python download_models.py --submit --region us-east-2 --model=gemma

# Run benchmarks
python benchmark.py --validate          # Preview job matrix
python benchmark.py --model=gemma       # Run locally
python benchmark.py --submit            # Run as Processing Job
```

## Results Pipeline

Results are written to a centralized Athena table with Hive-partitioned S3 storage:
- **Partitions:** `environment` / `model` / `workload`
- **Schema:** 55+ columns including metrics, serving context, config hash, and raw AIPerf JSON
- **Deduplication:** Deterministic `job_id` based on model + workload + concurrency + config hash
- **Visualization:** Designed for QuickSight with native filter axes (vLLM version, instance type, dataset, quantization)

## Dependencies

- Python 3.10+
- boto3, pyyaml, requests
- AWS CLI + kubectl (for HyperPod path)
- Helm (for LB Controller installation)
- SageMaker AI Benchmarking service (AIPerf)