### PR TITLE
Add async inference inline payload example

### DIFF
--- a/03-features/README.md
+++ b/03-features/README.md
@@ -5,3 +5,4 @@ This directory contains example notebooks that demonstrates SageMaker AI feature
 - [Inference Components](./inference-component/) - examples of how to use Inference Components on Amazon SageMaker AI
 - [Autoscaling](./autoscaling/) - examples of endpoint autoscaling (including scaling down to zero)
 - [Deployments](./deployment/) - examples of rolling and blue/green deployments on SageMaker AI
+- [Asynchronous Inference inline payloads](./async-inference-inline-payload/) - send the request payload inline with `Body` on `InvokeEndpointAsync` (no S3 upload) for payloads up to 128,000 bytes

--- a/03-features/async-inference-inline-payload/async_inline_payload.ipynb
+++ b/03-features/async-inference-inline-payload/async_inline_payload.ipynb
@@ -1,0 +1,338 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell01",
+   "metadata": {},
+   "source": "# Inline payloads for Amazon SageMaker Asynchronous Inference\n\nAmazon SageMaker Asynchronous Inference lets you queue inference requests and process them in the background — ideal for large payloads, long-running inference, and bursty traffic that can tolerate seconds-to-minutes latency. Until recently, every invocation required a two-step pattern: **upload the input to Amazon S3, then call the endpoint with the S3 URI** (`InputLocation`).\n\nWith inline payload support, `invoke_endpoint_async` now accepts a **`Body`** parameter — the same parameter name the synchronous `invoke_endpoint` API already uses. For payloads up to **128,000 bytes**, you can send the request body directly in the API call — no input upload to S3, no input bucket to manage, no `s3:PutObject` grant on the *input* path, and no stale input objects to clean up.\n\n> **Note on the output path.** Asynchronous inference always writes the *result* to the S3 location you configure (`AsyncInferenceConfig.OutputConfig.S3OutputPath`). Inline `Body` removes the **input** upload — it does not change the output path. You still configure an output S3 location, and the endpoint's execution role still needs `s3:PutObject` there to store results.\n\nThis notebook:\n\n1. Deploys a small, inexpensive asynchronous endpoint.\n2. Invokes it the **new** way — inline `Body`.\n3. Invokes it the **classic** way — `InputLocation` (S3) — to show full backward compatibility.\n4. Demonstrates the validation behavior (mutual exclusivity, size limit).\n5. Cleans up all resources.\n\n> **Prerequisite.** The inline `Body` parameter on `InvokeEndpointAsync` requires an AWS SDK new enough to include it. The setup section below detects it at runtime and fails early with an upgrade hint if your installed `boto3`/`botocore` is too old.\n\n> **Where to run this.** It runs as-is in **Amazon SageMaker Studio** (the execution role and credentials are ambient). It also runs in **Google Colab or on a laptop** — there's no SageMaker-managed role there, so first configure AWS credentials and set the `SAGEMAKER_ROLE_ARN` environment variable to an existing SageMaker execution role ARN. Either way the endpoint runs in your AWS account and incurs charges until the cleanup cell."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell02",
+   "metadata": {},
+   "source": [
+    "## 1. Setup\n",
+    "\n",
+    "Requires an AWS SDK new enough to expose the inline-body parameter on `invoke_endpoint_async`. Upgrade `boto3`/`sagemaker` first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell03",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "# Install a current SageMaker SDK and the latest boto3/botocore. The inline `Body`\n# parameter on InvokeEndpointAsync ships in a recent SDK release, so we install the\n# newest available rather than pinning an exact version. The next cell verifies the\n# capability at runtime — that check, not a version number, is the authoritative gate.\n# (If you manage dependencies elsewhere, just make sure boto3/botocore are recent\n# enough to expose `Body`; the guard below tells you if they are not.)\n%pip install -Uq sagemaker boto3 botocore"
+  },
+  {
+   "cell_type": "code",
+   "id": "cell04",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import json\nimport os\nimport time\nimport uuid\n\nimport boto3\nimport sagemaker\nfrom sagemaker.huggingface import HuggingFaceModel\n\nsess = sagemaker.Session()\nregion = sess.boto_region_name\nbucket = sess.default_bucket()\nprefix = \"async-inline-payload-demo\"\n\n# Resolve the SageMaker execution role.\n# - In SageMaker Studio / Notebook Instances this is ambient (get_execution_role()).\n# - Anywhere else (Google Colab, a laptop), Studio's ambient role does not exist, so\n#   set the SAGEMAKER_ROLE_ARN env var to an existing SageMaker execution role ARN\n#   and make sure AWS credentials are configured (e.g. via `aws configure` or env vars).\ntry:\n    role = sagemaker.get_execution_role()\nexcept Exception:\n    # Broad by design: outside Studio this can fail several ways — ValueError (the\n    # caller identity is a user, not a role), NoCredentialsError, or a ClientError.\n    # All of them mean \"no ambient role\", so fall back to an explicit env var.\n    role = os.environ.get(\"SAGEMAKER_ROLE_ARN\")\n    if not role:\n        raise RuntimeError(\n            \"Not running in SageMaker Studio, so no ambient execution role is \"\n            \"available. Set SAGEMAKER_ROLE_ARN to an existing SageMaker execution \"\n            \"role ARN (and configure AWS credentials) before running this notebook.\"\n        )\n\nsm_client = boto3.client(\"sagemaker\", region_name=region)\nsmr_client = boto3.client(\"sagemaker-runtime\", region_name=region)\ns3_client = boto3.client(\"s3\", region_name=region)\n\nprint(f\"sagemaker version : {sagemaker.__version__}\")\nprint(f\"boto3 version     : {boto3.__version__}\")\nprint(f\"region            : {region}\")\nprint(f\"role              : {role}\")\nprint(f\"bucket            : s3://{bucket}/{prefix}\")"
+  },
+  {
+   "cell_type": "code",
+   "id": "cell05",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Confirm the running SDK actually exposes the inline-body parameter before going further.\n",
+    "# This is a cheap guard so the notebook fails loudly (here) rather than mid-demo.\n",
+    "# The parameter is named \"Body\" (same as the synchronous InvokeEndpoint API); we also\n",
+    "# accept \"InputBody\" defensively in case an SDK build names it differently.\n",
+    "members = smr_client.meta.service_model.operation_model(\"InvokeEndpointAsync\").input_shape.members\n",
+    "inline_param = next((m for m in (\"Body\", \"InputBody\") if m in members), None)\n",
+    "\n",
+    "if inline_param is None:\n",
+    "    raise RuntimeError(\n",
+    "        \"This boto3/botocore build does not expose an inline-body parameter on \"\n",
+    "        \"InvokeEndpointAsync. Upgrade the SDK (see the pip cell above) and restart \"\n",
+    "        \"the kernel.\\n\"\n",
+    "        f\"Available InvokeEndpointAsync input members: {sorted(members)}\"\n",
+    "    )\n",
+    "\n",
+    "print(f\"Inline-body parameter detected: {inline_param!r}\")\n",
+    "print(\"Available InvokeEndpointAsync input members:\")\n",
+    "print(json.dumps(sorted(members), indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell06",
+   "metadata": {},
+   "source": [
+    "## 2. Deploy a small asynchronous endpoint\n",
+    "\n",
+    "We deploy a small Hugging Face text-classification model (`distilbert-base-uncased-finetuned-sst-2-english`, ~67M parameters) on a CPU instance (`ml.m5.xlarge`). It is cheap, downloads in well under a minute, and returns compact JSON — perfect for demonstrating the request *surface* rather than model performance.\n",
+    "\n",
+    "The only thing that makes an endpoint \"asynchronous\" is the **`AsyncInferenceConfig`** on the endpoint configuration (an S3 output location). The model container itself is unchanged — it receives the same HTTP request whether the payload arrived inline or from S3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell07",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# A small, CPU-friendly text-classification model from the Hugging Face Hub.\n",
+    "hub = {\n",
+    "    \"HF_MODEL_ID\": \"distilbert-base-uncased-finetuned-sst-2-english\",\n",
+    "    \"HF_TASK\": \"text-classification\",\n",
+    "}\n",
+    "\n",
+    "# Version pins map to the CPU Hugging Face inference DLC:\n",
+    "#   pytorch-inference:2.1.0-transformers4.37.0-cpu-py310-ubuntu22.04\n",
+    "# (the only py310 CPU Hugging Face inference image published at time of writing).\n",
+    "hf_model = HuggingFaceModel(\n",
+    "    env=hub,\n",
+    "    role=role,\n",
+    "    transformers_version=\"4.37.0\",\n",
+    "    pytorch_version=\"2.1.0\",\n",
+    "    py_version=\"py310\",\n",
+    "    sagemaker_session=sess,\n",
+    ")\n",
+    "\n",
+    "# Build the container/model definition WITHOUT deploying, so we can attach an\n",
+    "# AsyncInferenceConfig on the endpoint config ourselves.\n",
+    "container_def = hf_model.prepare_container_def(instance_type=\"ml.m5.xlarge\")\n",
+    "model_name = sagemaker.utils.name_from_base(\"async-inline-distilbert\")\n",
+    "sm_client.create_model(\n",
+    "    ModelName=model_name,\n",
+    "    ExecutionRoleArn=role,\n",
+    "    PrimaryContainer=container_def,\n",
+    ")\n",
+    "print(f\"Created model: {model_name}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell08",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Endpoint config with AsyncInferenceConfig -> this is what makes it an async endpoint.\n",
+    "endpoint_config_name = sagemaker.utils.name_from_base(\"async-inline-cfg\")\n",
+    "async_output_path = f\"s3://{bucket}/{prefix}/async-output\"\n",
+    "\n",
+    "sm_client.create_endpoint_config(\n",
+    "    EndpointConfigName=endpoint_config_name,\n",
+    "    ProductionVariants=[\n",
+    "        {\n",
+    "            \"VariantName\": \"AllTraffic\",\n",
+    "            \"ModelName\": model_name,\n",
+    "            \"InstanceType\": \"ml.m5.xlarge\",\n",
+    "            \"InitialInstanceCount\": 1,\n",
+    "        }\n",
+    "    ],\n",
+    "    AsyncInferenceConfig={\n",
+    "        \"OutputConfig\": {\n",
+    "            \"S3OutputPath\": async_output_path,\n",
+    "            # No S3FailurePath / no inline-response config here, to keep the demo simple.\n",
+    "        }\n",
+    "    },\n",
+    ")\n",
+    "print(f\"Created endpoint config: {endpoint_config_name}\")\n",
+    "print(f\"Async output path      : {async_output_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell09",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "endpoint_name = sagemaker.utils.name_from_base(\"async-inline-ep\")\n",
+    "sm_client.create_endpoint(\n",
+    "    EndpointName=endpoint_name,\n",
+    "    EndpointConfigName=endpoint_config_name,\n",
+    ")\n",
+    "print(f\"Creating endpoint: {endpoint_name} ... (typically 5-8 minutes)\")\n",
+    "\n",
+    "waiter = sm_client.get_waiter(\"endpoint_in_service\")\n",
+    "waiter.wait(EndpointName=endpoint_name, WaiterConfig={\"Delay\": 30, \"MaxAttempts\": 60})\n",
+    "print(f\"Endpoint in service: {endpoint_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell10",
+   "metadata": {},
+   "source": "## 3. A small helper to fetch async results\n\n`invoke_endpoint_async` returns immediately with an `OutputLocation` (an S3 URI). The model result is written there once inference completes — or, on a processing error, to the `FailureLocation`. The helper below takes the full invoke response and polls both, so a success returns the parsed JSON and a failure raises promptly instead of hanging. Both invocation styles below reuse it — the result-handling path is identical regardless of how the input was sent."
+  },
+  {
+   "cell_type": "code",
+   "id": "cell11",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "def _split_s3_uri(s3_uri):\n    assert s3_uri.startswith(\"s3://\"), s3_uri\n    b, k = s3_uri[len(\"s3://\"):].split(\"/\", 1)\n    return b, k\n\n\ndef wait_for_async_output(invoke_response, timeout_s=300, poll_s=5):\n    \"\"\"Poll the async result until it appears; return parsed JSON.\n\n    Pass the full invoke_endpoint_async response. The result is written to\n    OutputLocation on success, or to FailureLocation on model/processing error;\n    we poll both so a failure surfaces promptly instead of hanging until timeout.\n    \"\"\"\n    out_bucket, out_key = _split_s3_uri(invoke_response[\"OutputLocation\"])\n    fail_uri = invoke_response.get(\"FailureLocation\")\n    fail = _split_s3_uri(fail_uri) if fail_uri else None\n\n    deadline = time.time() + timeout_s\n    while time.time() < deadline:\n        try:\n            obj = s3_client.get_object(Bucket=out_bucket, Key=out_key)\n            return json.loads(obj[\"Body\"].read().decode(\"utf-8\"))\n        except s3_client.exceptions.NoSuchKey:\n            pass\n        if fail:\n            try:\n                err_obj = s3_client.get_object(Bucket=fail[0], Key=fail[1])\n                raise RuntimeError(\n                    \"Async inference failed; FailureLocation contains: \"\n                    + err_obj[\"Body\"].read().decode(\"utf-8\", \"replace\")\n                )\n            except s3_client.exceptions.NoSuchKey:\n                pass\n        time.sleep(poll_s)\n    raise TimeoutError(\n        f\"No async result at {invoke_response['OutputLocation']} after {timeout_s}s\"\n    )"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell12",
+   "metadata": {},
+   "source": [
+    "## 4. The new way — inline `Body`\n",
+    "\n",
+    "Send the payload directly in the API call. No S3 client, no upload, no input bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell13",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "payload = json.dumps({\"inputs\": \"Inline payloads make async inference so much simpler!\"}).encode(\"utf-8\")\n\n# `inline_param` was detected in the setup cell — it is \"Body\" on current SDKs.\nkwargs = {\n    \"EndpointName\": endpoint_name,\n    \"ContentType\": \"application/json\",\n    inline_param: payload,   # <-- the whole point: payload travels inline, no S3 upload\n}\n\nstart = time.time()\nresponse = smr_client.invoke_endpoint_async(**kwargs)\nsubmit_latency = time.time() - start\n\nprint(f\"Submitted inline in {submit_latency:.3f}s (no S3 upload)\")\nprint(f\"InferenceId    : {response.get('InferenceId')}\")\nprint(f\"OutputLocation : {response['OutputLocation']}\")\n\nresult = wait_for_async_output(response)\nprint(\"\\nModel result:\")\nprint(json.dumps(result, indent=2))"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell14",
+   "metadata": {},
+   "source": [
+    "## 5. The classic way — `InputLocation` (S3)\n",
+    "\n",
+    "For comparison and to prove backward compatibility: upload the payload to S3 first, then pass its URI as `InputLocation`. This is exactly how async inference worked before inline support — and it still works unchanged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell15",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "# 1. Upload the payload to S3 (the extra step inline payloads remove).\ninput_key = f\"{prefix}/async-input/{uuid.uuid4()}.json\"\ns3_client.put_object(\n    Bucket=bucket,\n    Key=input_key,\n    Body=json.dumps({\"inputs\": \"The classic S3 InputLocation path still works.\"}).encode(\"utf-8\"),\n)\ninput_location = f\"s3://{bucket}/{input_key}\"\nprint(f\"Uploaded input to: {input_location}\")\n\n# 2. Invoke with InputLocation (no inline Body).\nstart = time.time()\nresponse_s3 = smr_client.invoke_endpoint_async(\n    EndpointName=endpoint_name,\n    ContentType=\"application/json\",\n    InputLocation=input_location,\n)\nsubmit_latency_s3 = time.time() - start\n\nprint(f\"Submitted via S3 in {submit_latency_s3:.3f}s (upload + invoke)\")\nprint(f\"OutputLocation : {response_s3['OutputLocation']}\")\n\nresult_s3 = wait_for_async_output(response_s3)\nprint(\"\\nModel result:\")\nprint(json.dumps(result_s3, indent=2))"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell16",
+   "metadata": {},
+   "source": [
+    "Both calls hit the same endpoint, ran the same model, and produced the same shape of result. The only difference is how the input got there."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell17",
+   "metadata": {},
+   "source": "## 6. Validation behavior\n\nThe service validates inline requests **synchronously** — you get an immediate error before any work is queued. Two rules to know:\n\n1. **Mutual exclusivity** — you cannot set both `Body` and `InputLocation`. Provide exactly one.\n2. **Size limit** — inline `Body` cannot exceed **128,000 bytes**. This is a *byte* limit on the raw payload, not a character count: for text, it's the UTF-8 byte length, so multibyte characters (most non-ASCII text, emoji) count as more than one byte each. A safe client-side pre-check is `len(payload_bytes) <= 128_000`.\n\n> The exact error message strings are framework-generated and may differ slightly across SDK/service versions, so the cells below assert on the *exception type and behavior* rather than on an exact string. (The size limit is enforced by the service, not the SDK — so an oversized payload surfaces as a synchronous `ValidationError` from the API call below, not as a local SDK error.)"
+  },
+  {
+   "cell_type": "code",
+   "id": "cell18",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from botocore.exceptions import ClientError\n",
+    "\n",
+    "# 6a. Setting both Body and InputLocation is rejected synchronously.\n",
+    "both_kwargs = {\n",
+    "    \"EndpointName\": endpoint_name,\n",
+    "    \"ContentType\": \"application/json\",\n",
+    "    \"InputLocation\": input_location,\n",
+    "    inline_param: payload,\n",
+    "}\n",
+    "try:\n",
+    "    smr_client.invoke_endpoint_async(**both_kwargs)\n",
+    "    print(\"UNEXPECTED: the call was accepted. Check the SDK/service version.\")\n",
+    "except ClientError as e:\n",
+    "    err = e.response[\"Error\"]\n",
+    "    print(\"Rejected as expected when both Body and InputLocation are set:\")\n",
+    "    print(f\"  Code   : {err['Code']}\")\n",
+    "    print(f\"  Message: {err['Message']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell19",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# 6b. An oversized inline payload (> 128,000 bytes) is rejected synchronously.\n",
+    "oversized = json.dumps({\"inputs\": \"x\" * 130_000}).encode(\"utf-8\")\n",
+    "print(f\"Oversized payload size: {len(oversized):,} bytes\")\n",
+    "\n",
+    "over_kwargs = {\n",
+    "    \"EndpointName\": endpoint_name,\n",
+    "    \"ContentType\": \"application/json\",\n",
+    "    inline_param: oversized,\n",
+    "}\n",
+    "try:\n",
+    "    smr_client.invoke_endpoint_async(**over_kwargs)\n",
+    "    print(\"UNEXPECTED: the call was accepted. Check the SDK/service version.\")\n",
+    "except ClientError as e:\n",
+    "    err = e.response[\"Error\"]\n",
+    "    print(\"Rejected as expected for payload > 128,000 bytes:\")\n",
+    "    print(f\"  Code   : {err['Code']}\")\n",
+    "    print(f\"  Message: {err['Message']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell20",
+   "metadata": {},
+   "source": "## 7. When to use each approach\n\n| Scenario | Recommended approach |\n|---|---|\n| Payload &le; 128,000 bytes (JSON prompts, structured data) | **Inline `Body`** — simpler, faster, cheaper |\n| Payload > 128,000 bytes (images, audio, large documents) | **`InputLocation`** — upload to S3 first |\n| Mixed workload with variable payload sizes | Branch on size: `Body` for small, `InputLocation` for large |\n| You need to retain inputs in S3 for audit/replay | **`InputLocation`** — keeps inputs in your bucket |\n\nFor the common case of small payloads, inline `Body` removes an entire network round-trip and an `s3:PutObject` per request on the **input** path, and lets you drop the **input** bucket, its lifecycle policies, and the IAM grant on the input path. The **output** path is unchanged: async inference still writes results to your configured `S3OutputPath`, so you keep an output bucket and the execution role's `s3:PutObject` there."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell21",
+   "metadata": {},
+   "source": [
+    "## 8. Clean up\n",
+    "\n",
+    "Delete the endpoint, endpoint config, and model to stop incurring charges. Optionally remove the demo S3 objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell22",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "sm_client.delete_endpoint(EndpointName=endpoint_name)\n",
+    "sm_client.delete_endpoint_config(EndpointConfigName=endpoint_config_name)\n",
+    "sm_client.delete_model(ModelName=model_name)\n",
+    "print(\"Deleted endpoint, endpoint config, and model.\")\n",
+    "\n",
+    "# Optional: remove demo S3 objects (input + async output).\n",
+    "paginator = s3_client.get_paginator(\"list_objects_v2\")\n",
+    "to_delete = []\n",
+    "for page in paginator.paginate(Bucket=bucket, Prefix=prefix):\n",
+    "    to_delete.extend({\"Key\": o[\"Key\"]} for o in page.get(\"Contents\", []))\n",
+    "for i in range(0, len(to_delete), 1000):\n",
+    "    s3_client.delete_objects(Bucket=bucket, Delete={\"Objects\": to_delete[i:i + 1000]})\n",
+    "print(f\"Deleted {len(to_delete)} demo object(s) under s3://{bucket}/{prefix}.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Add a notebook under 03-features demonstrating the new inline Body parameter on InvokeEndpointAsync, which lets you send request payloads up to 128,000 bytes directly in the API call (no S3 upload) as an alternative to InputLocation. Includes deploy, inline + InputLocation invocation, validation behavior, and cleanup.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
