### PR TITLE
Add vLLM-Omni bidirectional streaming TTS sample

### DIFF
--- a/03-features/bidirectional-streaming-vLLM-Omni/.gitignore
+++ b/03-features/bidirectional-streaming-vLLM-Omni/.gitignore
@@ -1,0 +1,1 @@
+validation-output.wav

--- a/03-features/bidirectional-streaming-vLLM-Omni/README.md
+++ b/03-features/bidirectional-streaming-vLLM-Omni/README.md
@@ -89,6 +89,15 @@ endpoint deployment. Request quota for every fallback type that you want
 SageMaker to use. The hourly price can change when SageMaker selects a
 different instance type.
 
+Use `--instance-types` to restrict the pool to instance types that have quota
+in your account or that meet your price and performance requirements.
+
+```bash
+python deploy_bidi_stream.py \
+  --region us-east-2 \
+  --instance-types ml.g6e.xlarge ml.g5.xlarge ml.g4dn.xlarge
+```
+
 ## Try the Gradio application
 
 Launch the application against the endpoint that you kept running.

--- a/03-features/bidirectional-streaming-vLLM-Omni/README.md
+++ b/03-features/bidirectional-streaming-vLLM-Omni/README.md
@@ -1,0 +1,106 @@
+# Bidirectional streaming with vLLM-Omni on SageMaker AI
+
+This sample deploys Qwen3-TTS with the vLLM-Omni SageMaker Deep Learning
+Container. It includes a repeatable streaming smoke test and a Gradio
+application for trying text-to-speech in a browser.
+
+This example complements
+[`../bidirectional-streaming-vLLM/`](../bidirectional-streaming-vLLM/).
+The earlier example streams audio to a standard vLLM Realtime API endpoint
+for speech-to-text. This example streams text to the purpose-built
+vLLM-Omni container for text-to-speech.
+
+## Architecture
+
+The Python client opens an HTTP/2 WebSocket to SageMaker Runtime on port
+`8443`. The SageMaker inference sidecar forwards the connection to the
+vLLM-Omni `v1/audio/speech/stream` route. Qwen3-TTS returns audio lifecycle
+and chunk events over the same connection.
+
+## Prerequisites
+
+- Python 3.12 or newer
+- AWS credentials configured through an AWS profile, IAM Identity Center, or
+  an IAM role
+- A SageMaker execution role
+- Permission to create, invoke, and delete SageMaker models, endpoint
+  configurations, and endpoints
+- `ml.g6.xlarge` capacity in `us-east-1`, or another supported AWS Region
+
+The sample creates a GPU endpoint that incurs charges while it is running.
+Its cleanup routine waits for endpoint deletion before deleting the endpoint
+configuration and model.
+
+## Install
+
+Clone the repository and enter this sample directory.
+
+```bash
+git clone https://github.com/aws-samples/sagemaker-genai-hosting-examples.git
+cd sagemaker-genai-hosting-examples/03-features/bidirectional-streaming-vLLM-Omni
+```
+
+Create a virtual environment and install the pinned dependencies.
+
+```bash
+python3.12 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
+```
+
+## Run
+
+Set your SageMaker execution role, then deploy and validate the endpoint.
+The `--keep-endpoint` option leaves the endpoint running for the Gradio
+application.
+
+```bash
+export SAGEMAKER_EXECUTION_ROLE_ARN="arn:aws:iam::<account-id>:role/<role-name>"
+python deploy_bidi_stream.py \
+  --endpoint-name vllm-omni-bidi \
+  --keep-endpoint
+```
+
+The default Region is `us-east-1`. Override the Region or container image
+when required.
+
+```bash
+export AWS_REGION="us-west-2"
+export VLLM_OMNI_IMAGE_URI="763104351884.dkr.ecr.us-west-2.amazonaws.com/vllm:omni-sagemaker-cuda-v1.5"
+python deploy_bidi_stream.py
+```
+
+A successful run reports `audio.start` and `audio.done`, receives more than
+2,000 streamed PCM bytes, and saves `validation-output.wav`.
+
+## Try the Gradio application
+
+Launch the application against the endpoint that you kept running.
+
+```bash
+python sagemaker_bidi_tts_client.py \
+  --endpoint-name vllm-omni-bidi \
+  --region us-east-1
+```
+
+Open `http://127.0.0.1:6006`, enter text, and choose **Generate speech**.
+The application sends the text over a SageMaker bidirectional stream and
+plays the returned PCM chunks as they arrive.
+
+## Clean up
+
+Delete the endpoint, endpoint configuration, and model after testing.
+
+```bash
+python deploy_bidi_stream.py \
+  --endpoint-name vllm-omni-bidi \
+  --delete-endpoint
+```
+
+## Files
+
+- `deploy_bidi_stream.py` deploys, validates, retains, or deletes the endpoint.
+- `sagemaker_bidi_tts.py` contains the shared HTTP/2 streaming transport.
+- `sagemaker_bidi_tts_client.py` contains the Gradio application.
+- `requirements.txt` pins the SageMaker bidirectional streaming client and
+  the Gradio version used by this sample.

--- a/03-features/bidirectional-streaming-vLLM-Omni/README.md
+++ b/03-features/bidirectional-streaming-vLLM-Omni/README.md
@@ -22,10 +22,12 @@ and chunk events over the same connection.
 - Python 3.12 or newer
 - AWS credentials configured through an AWS profile, IAM Identity Center, or
   an IAM role
+- Boto3 1.40 or newer, installed by `requirements.txt`
 - A SageMaker execution role
 - Permission to create, invoke, and delete SageMaker models, endpoint
   configurations, and endpoints
-- `ml.g6.xlarge` capacity in `us-east-1`, or another supported AWS Region
+- Endpoint quota for at least one of `ml.g6.xlarge`, `ml.g6e.xlarge`,
+  `ml.g5.xlarge`, or `ml.g4dn.xlarge`
 
 The sample creates a GPU endpoint that incurs charges while it is running.
 Its cleanup routine waits for endpoint deletion before deleting the endpoint
@@ -61,17 +63,31 @@ python deploy_bidi_stream.py \
   --keep-endpoint
 ```
 
-The default Region is `us-east-1`. Override the Region or container image
-when required.
+The default Region is `us-east-1`. Use `--region` to deploy elsewhere. The
+script builds the regional container image URI automatically.
 
 ```bash
-export AWS_REGION="us-west-2"
-export VLLM_OMNI_IMAGE_URI="763104351884.dkr.ecr.us-west-2.amazonaws.com/vllm:omni-sagemaker-cuda-v1.5"
-python deploy_bidi_stream.py
+python deploy_bidi_stream.py --region us-west-2
 ```
 
 A successful run reports `audio.start` and `audio.done`, receives more than
 2,000 streamed PCM bytes, and saves `validation-output.wav`.
+
+### Instance pools
+
+The endpoint configuration uses a SageMaker instance pool instead of one
+fixed instance type. SageMaker tries the compatible GPU types in this order:
+
+1. `ml.g6.xlarge`
+2. `ml.g6e.xlarge`
+3. `ml.g5.xlarge`
+4. `ml.g4dn.xlarge`
+
+SageMaker still provisions one instance. If the preferred type has
+insufficient capacity, it tries the next type without requiring a new
+endpoint deployment. Request quota for every fallback type that you want
+SageMaker to use. The hourly price can change when SageMaker selects a
+different instance type.
 
 ## Try the Gradio application
 
@@ -94,6 +110,7 @@ Delete the endpoint, endpoint configuration, and model after testing.
 ```bash
 python deploy_bidi_stream.py \
   --endpoint-name vllm-omni-bidi \
+  --region us-east-1 \
   --delete-endpoint
 ```
 

--- a/03-features/bidirectional-streaming-vLLM-Omni/deploy_bidi_stream.py
+++ b/03-features/bidirectional-streaming-vLLM-Omni/deploy_bidi_stream.py
@@ -23,24 +23,23 @@ import wave
 
 import boto3
 from botocore.exceptions import ClientError
-from sagemaker.core.resources import Endpoint, EndpointConfig, Model
-from sagemaker.core.shapes import ContainerDefinition, ProductionVariant
 from sagemaker_bidi_tts import collect_pcm
 
 logger = logging.getLogger(__name__)
 
-REGION = os.environ.get("AWS_REGION", "us-east-1")
-IMAGE_URI = os.environ.get(
-    "VLLM_OMNI_IMAGE_URI",
-    (f"763104351884.dkr.ecr.{REGION}.amazonaws.com/vllm:omni-sagemaker-cuda-v1.5"),
-)
 EXECUTION_ROLE_ARN = os.environ.get(
     "SAGEMAKER_EXECUTION_ROLE_ARN",
     "arn:aws:iam::<account-id>:role/<sagemaker-execution-role>",
 )
 MODEL_ID = "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
-INSTANCE_TYPE = "ml.g6.xlarge"
+INSTANCE_TYPES = (
+    "ml.g6.xlarge",
+    "ml.g6e.xlarge",
+    "ml.g5.xlarge",
+    "ml.g4dn.xlarge",
+)
 INFERENCE_AMI_VERSION = "al2023-ami-sagemaker-inference-gpu-4-1"
+INSTANCE_PROVISION_TIMEOUT_SECONDS = 1200
 
 
 def validate_configuration():
@@ -60,9 +59,39 @@ def save_wav(path, pcm, sample_rate):
         output.writeframes(pcm)
 
 
-def delete_resources(resource_name):
+def image_uri(region):
+    """Return the regional vLLM-Omni DLC image URI."""
+    return os.environ.get(
+        "VLLM_OMNI_IMAGE_URI",
+        (f"763104351884.dkr.ecr.{region}.amazonaws.com/vllm:omni-sagemaker-cuda-v1.5"),
+    )
+
+
+def instance_pools():
+    """Return compatible GPU instance types in placement priority order."""
+    return [
+        {"InstanceType": instance_type, "Priority": priority}
+        for priority, instance_type in enumerate(INSTANCE_TYPES, start=1)
+    ]
+
+
+def production_variant(resource_name):
+    """Build the endpoint production variant with capacity fallbacks."""
+    return {
+        "VariantName": "AllTraffic",
+        "ModelName": resource_name,
+        "InitialInstanceCount": 1,
+        "InstancePools": instance_pools(),
+        "VariantInstanceProvisionTimeoutInSeconds": (
+            INSTANCE_PROVISION_TIMEOUT_SECONDS
+        ),
+        "InferenceAmiVersion": INFERENCE_AMI_VERSION,
+    }
+
+
+def delete_resources(resource_name, region):
     """Delete an endpoint, endpoint configuration, and model by name."""
-    sagemaker = boto3.client("sagemaker", region_name=REGION)
+    sagemaker = boto3.client("sagemaker", region_name=region)
     try:
         sagemaker.delete_endpoint(EndpointName=resource_name)
         sagemaker.get_waiter("endpoint_deleted").wait(
@@ -98,6 +127,10 @@ def main():
     """Deploy the endpoint, run one streaming request, and clean up."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--endpoint-name")
+    parser.add_argument(
+        "--region",
+        default=os.environ.get("AWS_REGION", "us-east-1"),
+    )
     parser.add_argument("--keep-endpoint", action="store_true")
     parser.add_argument("--delete-endpoint", action="store_true")
     parser.add_argument(
@@ -113,58 +146,59 @@ def main():
     if args.delete_endpoint:
         if not args.endpoint_name:
             parser.error("--delete-endpoint requires --endpoint-name")
-        delete_resources(resource_name)
+        delete_resources(resource_name, args.region)
         return
 
     validate_configuration()
+    region = args.region
+    regional_image_uri = image_uri(region)
     model_created = False
     endpoint_config_created = False
     endpoint_created = False
     validation_passed = False
 
     try:
-        print(f"Region: {REGION}")
-        print(f"Image: {IMAGE_URI}")
+        print(f"Region: {region}")
+        print(f"Image: {regional_image_uri}")
         print(f"Model: {MODEL_ID}")
-        print(f"Instance type: {INSTANCE_TYPE}")
-        Model.create(
-            model_name=resource_name,
-            primary_container=ContainerDefinition(
-                image=IMAGE_URI,
-                environment={"SM_VLLM_MODEL": MODEL_ID},
-            ),
-            execution_role_arn=EXECUTION_ROLE_ARN,
-            region=REGION,
+        print(f"Instance pools: {', '.join(INSTANCE_TYPES)}")
+        sagemaker = boto3.client("sagemaker", region_name=region)
+        sagemaker.create_model(
+            ModelName=resource_name,
+            PrimaryContainer={
+                "Image": regional_image_uri,
+                "Environment": {"SM_VLLM_MODEL": MODEL_ID},
+            },
+            ExecutionRoleArn=EXECUTION_ROLE_ARN,
         )
         model_created = True
-        EndpointConfig.create(
-            endpoint_config_name=resource_name,
-            region=REGION,
-            production_variants=[
-                ProductionVariant(
-                    variant_name="AllTraffic",
-                    model_name=resource_name,
-                    initial_instance_count=1,
-                    instance_type=INSTANCE_TYPE,
-                    inference_ami_version=INFERENCE_AMI_VERSION,
-                )
-            ],
+        sagemaker.create_endpoint_config(
+            EndpointConfigName=resource_name,
+            ProductionVariants=[production_variant(resource_name)],
         )
         endpoint_config_created = True
-        endpoint = Endpoint.create(
-            endpoint_name=resource_name,
-            endpoint_config_name=resource_name,
-            region=REGION,
+        sagemaker.create_endpoint(
+            EndpointName=resource_name,
+            EndpointConfigName=resource_name,
         )
         endpoint_created = True
         print(f"Deploying {resource_name}.")
-        endpoint.wait_for_status("InService", timeout=2400)
+        sagemaker.get_waiter("endpoint_in_service").wait(
+            EndpointName=resource_name,
+            WaiterConfig={"Delay": 30, "MaxAttempts": 80},
+        )
+        endpoint_description = sagemaker.describe_endpoint(EndpointName=resource_name)
+        selected_pools = endpoint_description["ProductionVariants"][0].get(
+            "InstancePools",
+            [],
+        )
+        print("Selected instance pools:", json.dumps(selected_pools, default=str))
 
         result = asyncio.run(
             collect_pcm(
                 resource_name,
                 args.text,
-                region=REGION,
+                region=region,
             )
         )
         audio_bytes = len(result["audio"])
@@ -191,15 +225,15 @@ def main():
             print(f"Kept endpoint: {resource_name}")
             print(
                 "Launch the UI with: python sagemaker_bidi_tts_client.py "
-                f"--endpoint-name {resource_name} --region {REGION}"
+                f"--endpoint-name {resource_name} --region {region}"
             )
             print(
                 "Delete resources with: python deploy_bidi_stream.py "
-                f"--endpoint-name {resource_name} --delete-endpoint"
+                f"--endpoint-name {resource_name} --region {region} --delete-endpoint"
             )
         elif model_created or endpoint_config_created or endpoint_created:
             try:
-                delete_resources(resource_name)
+                delete_resources(resource_name, region)
             except Exception as error:  # noqa: BLE001
                 logger.warning(
                     "Failed to delete %s: %s",

--- a/03-features/bidirectional-streaming-vLLM-Omni/deploy_bidi_stream.py
+++ b/03-features/bidirectional-streaming-vLLM-Omni/deploy_bidi_stream.py
@@ -67,21 +67,21 @@ def image_uri(region):
     )
 
 
-def instance_pools():
+def instance_pools(instance_types=INSTANCE_TYPES):
     """Return compatible GPU instance types in placement priority order."""
     return [
         {"InstanceType": instance_type, "Priority": priority}
-        for priority, instance_type in enumerate(INSTANCE_TYPES, start=1)
+        for priority, instance_type in enumerate(instance_types, start=1)
     ]
 
 
-def production_variant(resource_name):
+def production_variant(resource_name, instance_types=INSTANCE_TYPES):
     """Build the endpoint production variant with capacity fallbacks."""
     return {
         "VariantName": "AllTraffic",
         "ModelName": resource_name,
         "InitialInstanceCount": 1,
-        "InstancePools": instance_pools(),
+        "InstancePools": instance_pools(instance_types),
         "VariantInstanceProvisionTimeoutInSeconds": (
             INSTANCE_PROVISION_TIMEOUT_SECONDS
         ),
@@ -131,6 +131,12 @@ def main():
         "--region",
         default=os.environ.get("AWS_REGION", "us-east-1"),
     )
+    parser.add_argument(
+        "--instance-types",
+        nargs="+",
+        default=list(INSTANCE_TYPES),
+        metavar="INSTANCE_TYPE",
+    )
     parser.add_argument("--keep-endpoint", action="store_true")
     parser.add_argument("--delete-endpoint", action="store_true")
     parser.add_argument(
@@ -151,6 +157,9 @@ def main():
 
     validate_configuration()
     region = args.region
+    selected_instance_types = tuple(dict.fromkeys(args.instance_types))
+    if not 1 <= len(selected_instance_types) <= 5:
+        parser.error("--instance-types requires between one and five unique values")
     regional_image_uri = image_uri(region)
     model_created = False
     endpoint_config_created = False
@@ -161,7 +170,7 @@ def main():
         print(f"Region: {region}")
         print(f"Image: {regional_image_uri}")
         print(f"Model: {MODEL_ID}")
-        print(f"Instance pools: {', '.join(INSTANCE_TYPES)}")
+        print(f"Instance pools: {', '.join(selected_instance_types)}")
         sagemaker = boto3.client("sagemaker", region_name=region)
         sagemaker.create_model(
             ModelName=resource_name,
@@ -174,7 +183,9 @@ def main():
         model_created = True
         sagemaker.create_endpoint_config(
             EndpointConfigName=resource_name,
-            ProductionVariants=[production_variant(resource_name)],
+            ProductionVariants=[
+                production_variant(resource_name, selected_instance_types)
+            ],
         )
         endpoint_config_created = True
         sagemaker.create_endpoint(

--- a/03-features/bidirectional-streaming-vLLM-Omni/deploy_bidi_stream.py
+++ b/03-features/bidirectional-streaming-vLLM-Omni/deploy_bidi_stream.py
@@ -1,0 +1,212 @@
+"""Deploy vLLM-Omni and stream text-to-speech through SageMaker AI.
+
+This sample deploys the vLLM-Omni SageMaker Deep Learning Container, opens a
+SageMaker bidirectional stream to the native TTS WebSocket route, sends text,
+validates the streamed audio response, and deletes the created resources.
+
+Prerequisites:
+    Python 3.12 or newer
+    An AWS identity that can create and invoke SageMaker AI endpoints
+    A SageMaker AI execution role
+
+Install:
+    python -m pip install -r requirements.txt
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import time
+import wave
+
+import boto3
+from botocore.exceptions import ClientError
+from sagemaker.core.resources import Endpoint, EndpointConfig, Model
+from sagemaker.core.shapes import ContainerDefinition, ProductionVariant
+from sagemaker_bidi_tts import collect_pcm
+
+logger = logging.getLogger(__name__)
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+IMAGE_URI = os.environ.get(
+    "VLLM_OMNI_IMAGE_URI",
+    (f"763104351884.dkr.ecr.{REGION}.amazonaws.com/vllm:omni-sagemaker-cuda-v1.5"),
+)
+EXECUTION_ROLE_ARN = os.environ.get(
+    "SAGEMAKER_EXECUTION_ROLE_ARN",
+    "arn:aws:iam::<account-id>:role/<sagemaker-execution-role>",
+)
+MODEL_ID = "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+INSTANCE_TYPE = "ml.g6.xlarge"
+INFERENCE_AMI_VERSION = "al2023-ami-sagemaker-inference-gpu-4-1"
+
+
+def validate_configuration():
+    """Fail before resource creation when required values are placeholders."""
+    if "<" in EXECUTION_ROLE_ARN or ">" in EXECUTION_ROLE_ARN:
+        raise ValueError(
+            "Set SAGEMAKER_EXECUTION_ROLE_ARN to a SageMaker execution role."
+        )
+
+
+def save_wav(path, pcm, sample_rate):
+    """Write mono 16-bit PCM as a WAV file."""
+    with wave.open(path, "wb") as output:
+        output.setnchannels(1)
+        output.setsampwidth(2)
+        output.setframerate(sample_rate)
+        output.writeframes(pcm)
+
+
+def delete_resources(resource_name):
+    """Delete an endpoint, endpoint configuration, and model by name."""
+    sagemaker = boto3.client("sagemaker", region_name=REGION)
+    try:
+        sagemaker.delete_endpoint(EndpointName=resource_name)
+        sagemaker.get_waiter("endpoint_deleted").wait(
+            EndpointName=resource_name,
+            WaiterConfig={"Delay": 15, "MaxAttempts": 80},
+        )
+        print(f"Deleted endpoint: {resource_name}")
+    except ClientError as error:
+        if "Could not find" not in str(error):
+            raise
+
+    for operation, label, argument in [
+        (
+            sagemaker.delete_endpoint_config,
+            "endpoint configuration",
+            {"EndpointConfigName": resource_name},
+        ),
+        (
+            sagemaker.delete_model,
+            "model",
+            {"ModelName": resource_name},
+        ),
+    ]:
+        try:
+            operation(**argument)
+            print(f"Deleted {label}: {resource_name}")
+        except ClientError as error:
+            if "Could not find" not in str(error):
+                raise
+
+
+def main():
+    """Deploy the endpoint, run one streaming request, and clean up."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--endpoint-name")
+    parser.add_argument("--keep-endpoint", action="store_true")
+    parser.add_argument("--delete-endpoint", action="store_true")
+    parser.add_argument(
+        "--text",
+        default=(
+            "Hello, this response is streaming from vLLM-Omni on Amazon SageMaker AI."
+        ),
+    )
+    parser.add_argument("--output", default="validation-output.wav")
+    args = parser.parse_args()
+
+    resource_name = args.endpoint_name or f"vllm-omni-bidi-{int(time.time())}"
+    if args.delete_endpoint:
+        if not args.endpoint_name:
+            parser.error("--delete-endpoint requires --endpoint-name")
+        delete_resources(resource_name)
+        return
+
+    validate_configuration()
+    model_created = False
+    endpoint_config_created = False
+    endpoint_created = False
+    validation_passed = False
+
+    try:
+        print(f"Region: {REGION}")
+        print(f"Image: {IMAGE_URI}")
+        print(f"Model: {MODEL_ID}")
+        print(f"Instance type: {INSTANCE_TYPE}")
+        Model.create(
+            model_name=resource_name,
+            primary_container=ContainerDefinition(
+                image=IMAGE_URI,
+                environment={"SM_VLLM_MODEL": MODEL_ID},
+            ),
+            execution_role_arn=EXECUTION_ROLE_ARN,
+            region=REGION,
+        )
+        model_created = True
+        EndpointConfig.create(
+            endpoint_config_name=resource_name,
+            region=REGION,
+            production_variants=[
+                ProductionVariant(
+                    variant_name="AllTraffic",
+                    model_name=resource_name,
+                    initial_instance_count=1,
+                    instance_type=INSTANCE_TYPE,
+                    inference_ami_version=INFERENCE_AMI_VERSION,
+                )
+            ],
+        )
+        endpoint_config_created = True
+        endpoint = Endpoint.create(
+            endpoint_name=resource_name,
+            endpoint_config_name=resource_name,
+            region=REGION,
+        )
+        endpoint_created = True
+        print(f"Deploying {resource_name}.")
+        endpoint.wait_for_status("InService", timeout=2400)
+
+        result = asyncio.run(
+            collect_pcm(
+                resource_name,
+                args.text,
+                region=REGION,
+            )
+        )
+        audio_bytes = len(result["audio"])
+        print(
+            "Stream result:",
+            json.dumps(
+                {
+                    "audio_bytes": audio_bytes,
+                    "sample_rate": result["sample_rate"],
+                    "saw_start": result["saw_start"],
+                    "saw_done": result["saw_done"],
+                }
+            ),
+        )
+        if not result["saw_start"] or not result["saw_done"]:
+            raise RuntimeError("The expected audio lifecycle events were missing.")
+        if audio_bytes <= 2_000:
+            raise RuntimeError("The endpoint returned too little audio.")
+        save_wav(args.output, result["audio"], result["sample_rate"])
+        print(f"Saved validation audio: {args.output}")
+        validation_passed = True
+    finally:
+        if args.keep_endpoint and validation_passed:
+            print(f"Kept endpoint: {resource_name}")
+            print(
+                "Launch the UI with: python sagemaker_bidi_tts_client.py "
+                f"--endpoint-name {resource_name} --region {REGION}"
+            )
+            print(
+                "Delete resources with: python deploy_bidi_stream.py "
+                f"--endpoint-name {resource_name} --delete-endpoint"
+            )
+        elif model_created or endpoint_config_created or endpoint_created:
+            try:
+                delete_resources(resource_name)
+            except Exception as error:  # noqa: BLE001
+                logger.warning(
+                    "Failed to delete %s: %s",
+                    resource_name,
+                    error,
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/03-features/bidirectional-streaming-vLLM-Omni/requirements.txt
+++ b/03-features/bidirectional-streaming-vLLM-Omni/requirements.txt
@@ -1,0 +1,5 @@
+boto3>=1.40.0,<2
+sagemaker>=3.3.1,<4
+aws_sdk_sagemaker_runtime_http2==0.4.0
+gradio==6.9.0
+numpy>=2.0,<3

--- a/03-features/bidirectional-streaming-vLLM-Omni/requirements.txt
+++ b/03-features/bidirectional-streaming-vLLM-Omni/requirements.txt
@@ -1,5 +1,4 @@
 boto3>=1.40.0,<2
-sagemaker>=3.3.1,<4
 aws_sdk_sagemaker_runtime_http2==0.4.0
 gradio==6.9.0
 numpy>=2.0,<3

--- a/03-features/bidirectional-streaming-vLLM-Omni/sagemaker_bidi_tts.py
+++ b/03-features/bidirectional-streaming-vLLM-Omni/sagemaker_bidi_tts.py
@@ -1,0 +1,199 @@
+"""Shared SageMaker bidirectional streaming helpers for vLLM-Omni TTS."""
+
+import asyncio
+import base64
+import json
+import logging
+import os
+
+import boto3
+from aws_sdk_sagemaker_runtime_http2.client import SageMakerRuntimeHTTP2Client
+from aws_sdk_sagemaker_runtime_http2.config import (
+    Config,
+    HTTPAuthSchemeResolver,
+)
+from aws_sdk_sagemaker_runtime_http2.models import (
+    InvokeEndpointWithBidirectionalStreamInput,
+    RequestPayloadPart,
+    RequestStreamEventPayloadPart,
+    ResponseStreamEventInternalStreamFailure,
+    ResponseStreamEventModelStreamError,
+    ResponseStreamEventPayloadPart,
+    ResponseStreamEventUnknown,
+)
+from smithy_aws_core.auth.sigv4 import SigV4AuthScheme
+from smithy_aws_core.identity import EnvironmentCredentialsResolver
+
+SPEECH_STREAM_PATH = "v1/audio/speech/stream"
+DEFAULT_SAMPLE_RATE = 24_000
+logger = logging.getLogger(__name__)
+
+
+def make_bidi_client(region):
+    """Create the SageMaker Runtime HTTP/2 client."""
+    credentials = boto3.Session().get_credentials()
+    if credentials is None:
+        raise RuntimeError("No AWS credentials found.")
+
+    frozen = credentials.get_frozen_credentials()
+    os.environ["AWS_ACCESS_KEY_ID"] = frozen.access_key
+    os.environ["AWS_SECRET_ACCESS_KEY"] = frozen.secret_key
+    if frozen.token:
+        os.environ["AWS_SESSION_TOKEN"] = frozen.token
+
+    config = Config(
+        endpoint_uri=(f"https://runtime.sagemaker.{region}.amazonaws.com:8443"),
+        region=region,
+        aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
+        auth_scheme_resolver=HTTPAuthSchemeResolver(),
+        auth_schemes={"aws.auth#sigv4": SigV4AuthScheme(service="sagemaker")},
+    )
+    return SageMakerRuntimeHTTP2Client(config=config)
+
+
+async def send_json(stream, message):
+    """Send one complete UTF-8 JSON message."""
+    payload = RequestPayloadPart(
+        bytes_=json.dumps(message).encode("utf-8"),
+        data_type="UTF8",
+        completion_state="COMPLETE",
+    )
+    await stream.input_stream.send(RequestStreamEventPayloadPart(value=payload))
+
+
+async def stream_pcm_events(
+    endpoint_name,
+    text,
+    region="us-east-1",
+    voice="Vivian",
+    language="English",
+    deadline_seconds=180,
+):
+    """Yield lifecycle events and PCM chunks from one TTS request."""
+    client = make_bidi_client(region)
+    request = InvokeEndpointWithBidirectionalStreamInput(
+        endpoint_name=endpoint_name,
+        model_invocation_path=SPEECH_STREAM_PATH,
+    )
+    stream = await client.invoke_endpoint_with_bidirectional_stream(input=request)
+    loop = asyncio.get_running_loop()
+    sample_rate = DEFAULT_SAMPLE_RATE
+
+    try:
+        _, receiver = await stream.await_output()
+        await send_json(
+            stream,
+            {
+                "type": "session.config",
+                "voice": voice,
+                "language": language,
+                "response_format": "pcm",
+                "stream_audio": True,
+            },
+        )
+        await send_json(stream, {"type": "input.text", "text": text})
+        await send_json(stream, {"type": "input.done"})
+
+        started_at = loop.time()
+        while loop.time() - started_at < deadline_seconds:
+            remaining = deadline_seconds - (loop.time() - started_at)
+            try:
+                event = await asyncio.wait_for(
+                    receiver.receive(),
+                    timeout=remaining,
+                )
+            except asyncio.TimeoutError as error:
+                raise TimeoutError("Timed out waiting for streamed audio.") from error
+
+            if event is None:
+                raise RuntimeError("The response stream ended unexpectedly.")
+            if isinstance(event, ResponseStreamEventModelStreamError):
+                raise RuntimeError(  # noqa: TRY004
+                    f"Model stream error: {event.value.error_code}: "
+                    f"{event.value.message}"
+                )
+            if isinstance(event, ResponseStreamEventInternalStreamFailure):
+                raise RuntimeError(  # noqa: TRY004
+                    f"Internal stream failure: {event.value.message}"
+                )
+            if isinstance(event, ResponseStreamEventUnknown):
+                raise RuntimeError(  # noqa: TRY004
+                    f"Unknown response event: {event.tag}"
+                )
+            if not isinstance(event, ResponseStreamEventPayloadPart):
+                raise RuntimeError(  # noqa: TRY004
+                    f"Unexpected response event: {type(event).__name__}"
+                )
+
+            payload = event.value
+            raw = payload.bytes_ or b""
+            if (payload.data_type or "").upper() != "UTF8":
+                if raw:
+                    yield {
+                        "type": "audio.chunk",
+                        "audio": raw,
+                        "sample_rate": sample_rate,
+                    }
+                continue
+
+            message = json.loads(raw.decode("utf-8"))
+            event_type = message.get("type")
+            if event_type == "audio.start":
+                sample_rate = int(message.get("sample_rate") or DEFAULT_SAMPLE_RATE)
+                yield message
+            elif event_type == "audio.chunk":
+                audio = base64.b64decode(message.get("audio_b64") or "")
+                if audio:
+                    yield {
+                        **message,
+                        "audio": audio,
+                        "sample_rate": int(message.get("sample_rate") or sample_rate),
+                    }
+            elif event_type == "audio.done":
+                yield message
+            elif event_type == "session.done":
+                yield message
+                return
+            elif event_type == "error":
+                raise RuntimeError(
+                    message.get("message") or "The model returned an error."
+                )
+    finally:
+        try:
+            await send_json(stream, {"type": "session.close"})
+        except Exception:
+            logger.debug("Failed to send session.close.", exc_info=True)
+        try:
+            await stream.input_stream.close()
+        except Exception:
+            logger.debug("Failed to close the input stream.", exc_info=True)
+
+
+async def collect_pcm(endpoint_name, text, **kwargs):
+    """Collect one streamed response for repeatable validation."""
+    chunks = []
+    sample_rate = DEFAULT_SAMPLE_RATE
+    saw_start = False
+    saw_done = False
+
+    async for event in stream_pcm_events(
+        endpoint_name,
+        text,
+        **kwargs,
+    ):
+        event_type = event.get("type")
+        if event_type == "audio.start":
+            saw_start = True
+            sample_rate = int(event.get("sample_rate") or DEFAULT_SAMPLE_RATE)
+        elif event_type == "audio.chunk":
+            chunks.append(event["audio"])
+            sample_rate = int(event.get("sample_rate") or sample_rate)
+        elif event_type == "audio.done":
+            saw_done = True
+
+    return {
+        "audio": b"".join(chunks),
+        "sample_rate": sample_rate,
+        "saw_start": saw_start,
+        "saw_done": saw_done,
+    }

--- a/03-features/bidirectional-streaming-vLLM-Omni/sagemaker_bidi_tts_client.py
+++ b/03-features/bidirectional-streaming-vLLM-Omni/sagemaker_bidi_tts_client.py
@@ -1,0 +1,114 @@
+"""Gradio client for streaming vLLM-Omni TTS on SageMaker AI."""
+
+import argparse
+
+import gradio as gr
+import numpy as np
+from sagemaker_bidi_tts import stream_pcm_events
+
+
+async def stream_audio(
+    endpoint_name,
+    region,
+    text,
+    voice,
+    language,
+):
+    """Yield Gradio audio chunks and progress text."""
+    if not text or not text.strip():
+        raise gr.Error("Enter text to synthesize.")
+
+    total_bytes = 0
+    chunk_count = 0
+    async for event in stream_pcm_events(
+        endpoint_name=endpoint_name,
+        text=text.strip(),
+        region=region,
+        voice=voice.strip() or "Vivian",
+        language=language,
+    ):
+        if event.get("type") != "audio.chunk":
+            continue
+
+        pcm = np.frombuffer(event["audio"], dtype=np.int16).copy()
+        total_bytes += len(event["audio"])
+        chunk_count += 1
+        status = f"Streaming chunk {chunk_count}, {total_bytes:,} audio bytes received."
+        yield (event["sample_rate"], pcm), status
+
+    if chunk_count == 0:
+        raise gr.Error("The endpoint returned no audio.")
+
+
+def build_demo(endpoint_name, region):
+    """Build the interactive text-to-speech application."""
+
+    async def synthesize(text, voice, language):
+        async for output in stream_audio(
+            endpoint_name,
+            region,
+            text,
+            voice,
+            language,
+        ):
+            yield output
+
+    with gr.Blocks(title="Streaming TTS with vLLM-Omni") as demo:
+        gr.Markdown("# Streaming text-to-speech")
+        gr.Markdown(
+            "Generate speech with vLLM-Omni through an Amazon SageMaker AI "
+            "bidirectional stream."
+        )
+        text = gr.Textbox(
+            label="Text",
+            value=(
+                "Hello, this response is streaming from vLLM-Omni "
+                "on Amazon SageMaker AI."
+            ),
+            lines=4,
+            max_lines=8,
+        )
+        with gr.Row():
+            voice = gr.Textbox(label="Voice", value="Vivian")
+            language = gr.Dropdown(
+                label="Language",
+                choices=["English", "Chinese", "Auto"],
+                value="English",
+            )
+        generate = gr.Button("Generate speech", variant="primary")
+        audio = gr.Audio(
+            label="Streamed audio",
+            streaming=True,
+            autoplay=True,
+        )
+        status = gr.Textbox(label="Status", interactive=False)
+
+        generate.click(
+            synthesize,
+            inputs=[text, voice, language],
+            outputs=[audio, status],
+        )
+
+    return demo
+
+
+def main():
+    """Parse command-line options and launch Gradio."""
+    parser = argparse.ArgumentParser(
+        description="Stream vLLM-Omni TTS from a SageMaker endpoint."
+    )
+    parser.add_argument("--endpoint-name", required=True)
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument("--server-port", type=int, default=6006)
+    parser.add_argument("--share", action="store_true")
+    args = parser.parse_args()
+
+    demo = build_demo(args.endpoint_name, args.region)
+    demo.queue().launch(
+        server_port=args.server_port,
+        share=args.share,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds an end-to-end text-to-speech example for the vLLM-Omni
SageMaker Deep Learning Container (DLC). It deploys
`Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice`, opens a SageMaker bidirectional
HTTP/2 stream, sends text, receives PCM audio chunks, and provides a Gradio
application for trying the endpoint in a browser.

The example complements
`03-features/bidirectional-streaming-vLLM/`. That sample covers the input
side of a voice application by streaming microphone audio to a standard
vLLM endpoint for speech-to-text. This sample covers the output side by
streaming generated speech from the purpose-built vLLM-Omni DLC.

## Example flow

1. Create a SageMaker model using the regional vLLM-Omni v1.5 DLC image.
2. Create an endpoint configuration with a priority-ordered GPU instance
   pool.
3. Deploy the endpoint and wait for it to reach `InService`.
4. Open `v1/audio/speech/stream` through the SageMaker Runtime HTTP/2
   bidirectional streaming API.
5. Send session configuration and text events.
6. Validate `audio.start`, streamed PCM chunks, and `audio.done`.
7. Save the response as a WAV file.
8. Optionally retain the endpoint and launch the Gradio client.
9. Delete the endpoint, endpoint configuration, and model.

## Instance pools

The endpoint uses SageMaker instance pools instead of one fixed instance
type:

1. `ml.g6.xlarge`
2. `ml.g6e.xlarge`
3. `ml.g5.xlarge`
4. `ml.g4dn.xlarge`

SageMaker provisions one instance and tries the pool entries in priority
order. If the preferred type lacks capacity, SageMaker can select the next
compatible type without requiring a new endpoint configuration.

The `--instance-types` option lets users restrict the pool to types that
match their available quota, price, and performance requirements. SageMaker
validates quota for every type included in the pool at endpoint creation,
even though it ultimately provisions only one instance.

## Files

- `deploy_bidi_stream.py` creates, validates, retains, and deletes the
  SageMaker resources. It also saves a repeatable smoke-test response as WAV.
- `sagemaker_bidi_tts.py` contains the shared SageMaker Runtime HTTP/2
  transport and vLLM-Omni event handling.
- `sagemaker_bidi_tts_client.py` provides the Gradio streaming
  text-to-speech interface.
- `requirements.txt` pins the preview SageMaker Runtime HTTP/2 SDK and
  Gradio version used by the example.
- `README.md` documents prerequisites, deployment, instance pools, browser
  testing, and cleanup.

## End-to-end validation

Validated on 20 August 2026 with:

- Python 3.12.11
- Boto3 1.43.75
- SageMaker Runtime HTTP/2 SDK 0.4.0
- Gradio 6.9.0
- vLLM-Omni DLC image digest
  `sha256:b0c62430c883af43bcfee8f5ff00c1412822c24532c3470f167760744b8f874b`

| Region | Selected instance | PCM bytes | Sample rate | Stream time |
| --- | --- | ---: | ---: | ---: |
| `us-east-1` | `ml.g5.xlarge` | 330,240 | 24 kHz | 6.19 seconds |
| `us-east-2` | `ml.g6e.xlarge` | 261,120 | 24 kHz | 5.19 seconds |
| `us-west-2` | `ml.g5.xlarge` | 241,920 | 24 kHz | 5.64 seconds |

Every regional run:

- reached `InService`;
- used the same DLC image digest;
- received `audio.start` and `audio.done`;
- returned streamed PCM audio;
- wrote a valid WAV file; and
- deleted the endpoint, endpoint configuration, and model after testing.

The Gradio browser flow was also tested against the `us-east-2` endpoint. It
streamed five chunks and 307,200 audio bytes, updated the progress field,
and exposed the generated audio through the player.

## Quality checks

- clean installation from `requirements.txt` in a Python 3.12 environment
- Ruff check and format passed
- Bandit reported no findings
- detect-secrets reported no source findings
- Boto3 payload verified with `InstancePools` and no fixed `InstanceType`

## Planned location

`03-features/bidirectional-streaming-vLLM-Omni/`